### PR TITLE
Migrate to SDK 1.3.0-dev.5.2 observatory API

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,14 +12,14 @@ Tools
 
 #### Collecting coverage from the VM
 
-    dart --enable-vm-service:NNNN --pin-isolates script.dart
-    dart bin/collect_coverage.dart --port=NNNN -o coverage.json --unpin-isolates
+    dart --enable-vm-service:NNNN --pause_isolates_on_exit script.dart
+    dart bin/collect_coverage.dart --port=NNNN -o coverage.json --resume-isolates
 
-The `--pin-isolates` VM flag is used to prevent isolates from being cleaned up
-until coverage has been collected. `collect_coverage.dart` can be invoked before
-the VM from which coverage is to be collected, and will wait until it detects
-a VM observatory port. An optional `--connect-timeout` may be specified in
-in seconds.
+The `--pause_isolates_on_exit` VM flag is used to pause isolates from being on
+exit to allow coverage to be collected. If `collect_coverage.dart` is invoked
+before the script from which coverage is to be collected, it will wait until it
+detects a VM observatory port to which it can connect. An optional
+`--connect-timeout` may be specified (in seconds).
 
 #### Collecting coverage from Dartium
 

--- a/bin/collect_coverage.dart
+++ b/bin/collect_coverage.dart
@@ -23,9 +23,9 @@ Future<Map> getAllCoverage(Observatory observatory) {
     });
 }
 
-Future unpinIsolates(Observatory observatory) {
+Future resumeIsolates(Observatory observatory) {
   return observatory.getIsolates()
-      .then((isolates) => isolates.map((i) => i.unpin()))
+      .then((isolates) => isolates.map((i) => i.resume()))
       .then(Future.wait);
 }
 
@@ -49,7 +49,7 @@ void main(List<String> arguments) {
           .then(JSON.encode)
           .then(options.out.write)
           .then((_) => options.out.close())
-          .then((_) => options.unpin ? unpinIsolates(observatory) : null)
+          .then((_) => options.resume ? resumeIsolates(observatory) : null)
           .then((_) => observatory.close());
     }, onError: (_) {
       if ((options.timeout != null) && (watch.elapsed > options.timeout)) {
@@ -66,8 +66,8 @@ class Options {
   final String port;
   final IOSink out;
   final Duration timeout;
-  final bool unpin;
-  Options(this.host, this.port, this.out, this.timeout, this.unpin);
+  final bool resume;
+  Options(this.host, this.port, this.out, this.timeout, this.resume);
 }
 
 Options parseArgs(List<String> arguments) {
@@ -80,8 +80,8 @@ Options parseArgs(List<String> arguments) {
       help: 'output: may be file or stdout');
   parser.addOption('connect-timeout', abbr: 't',
       help: 'connect timeout in seconds');
-  parser.addFlag('unpin-isolates', abbr: 'u', defaultsTo: false,
-      help: 'unpin all isolates on exit');
+  parser.addFlag('resume-isolates', abbr: 'r', defaultsTo: false,
+      help: 'resume all isolates on exit');
   parser.addFlag('help', abbr: 'h', negatable: false,
       help: 'show this help');
   var args = parser.parse(arguments);
@@ -115,5 +115,5 @@ Options parseArgs(List<String> arguments) {
   var timeout = (args['connect-timeout'] == null) ? null
       : new Duration(seconds: int.parse(args['connect-timeout']));
   return new Options(args['host'], args['port'], out, timeout,
-      args['unpin-isolates']);
+      args['resume-isolates']);
 }

--- a/lib/src/devtools.dart
+++ b/lib/src/devtools.dart
@@ -19,7 +19,7 @@ class IsolateInfo {
       _connection.request('isolates/$name/coverage')
       .then((resp) => resp['coverage']);
 
-  Future unpin() => _connection.request('isolates/$name/unpin');
+  Future resume() => _connection.request('isolates/$name/resume');
 }
 
 /// Interface to Dart's VM Observatory

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -3,6 +3,8 @@ version: 0.3.1
 author: Dart Team <misc@dartlang.org>
 description: Coverage data manipulation and formatting
 homepage: https://github.com/dart-lang/coverage
+environment:
+  sdk: '>=1.3.0-dev.5.2 <2.0.0'
 dependencies:
   args: '>=0.9.0 <2.0.0'
   http: '>=0.9.0 <2.0.0'


### PR DESCRIPTION
- --pin-isolates is replaced by --pause_isolates_on_exit
- the observatory /unpin query is now /resume
- collect_coverage --unpin-isolates is replaced with --resume-isolates
