### PR TITLE
correcting path to /isolate/<isolate id>/debug/resume

### DIFF
--- a/lib/src/devtools.dart
+++ b/lib/src/devtools.dart
@@ -26,7 +26,7 @@ class IsolateInfo {
     return _connection.request('isolates/$name/allocationprofile$params');
   }
 
-  Future resume() => _connection.request('isolates/$name/resume');
+  Future resume() => _connection.request('isolates/$name/debug/resume');
 }
 
 /// Interface to Dart's VM Observatory


### PR DESCRIPTION
@johnmccutchan is `/isolate/<isolate id>/resume` a valid path? 

If so what determines to use `/isolate/<isolate id>/debug/resume` or  `/isolate/<isolate id>/resume`? 

If there a way to tell which resume should be called?

I'm executing unit test scripts with `dart --enable-vm-service --pause-isolates-on-exit test/all.dart` and want to resume to exit the unit test runner. 
