### PR TITLE
Patched isolate pause flag detection for newer VM versions

### DIFF
--- a/lib/src/devtools.dart
+++ b/lib/src/devtools.dart
@@ -15,7 +15,7 @@ class IsolateInfo {
   final bool paused;
   IsolateInfo(this._connection, Map json) :
     name = json['mainPort'],
-    paused = json['pausedOnExit'];
+    paused = json['pausedOnExit'] || json.containsKey('pauseEvent');
 
   Future<Map> getCoverage() =>
       _connection.request('isolates/$name/coverage')


### PR DESCRIPTION
Newer observatory versions return the following block for paused isolates when querying their status:

```json
{
  "pauseEvent":{
     "type":"DebuggerEvent"
     ,"id":""
     ,"eventType":"IsolateShutdown"
}
```

With this patch, ```collect_coverage.dart``` will not hang indefinitely when invoked with ```--wait-paused```