### PR TITLE
Support Dart VM >= 1.9.0 websocket observatory protocol.

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -8,4 +8,5 @@ environment:
 dependencies:
   args: '>=0.9.0 <2.0.0'
   http: '>=0.9.0 <2.0.0'
+  logging: '>=0.9.0 <0.10.0'
   path: '>=0.9.0 <2.0.0'


### PR DESCRIPTION
In Dart SDK 1.9.0, access to the VM Observatory via the Chromium remote debugging protocol is no longer supported, and replaced with a JSON-rpc websocket interface via the observatory port. This behaviour is consistent with the VM websocket interface.

This patch applies the old behaviour on pre-1.9.0 VMs and the websocket JSON-rpc protocol for 1.9.0 and later.