### PR TITLE
Task36 single command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+0.6.0+1
+   * Add support for `pub global run`
+
 0.6.0
    * Add support for SDK versions >= 1.9.0. For Dartium/content-shell versions
      past 1.9.0, coverage collection is no longer done over the remote debugging

--- a/README.md
+++ b/README.md
@@ -12,10 +12,22 @@ Tools
 `format_coverage.dart` formats JSON coverage data into either
 [LCOV](http://ltp.sourceforge.net/coverage/lcov.php) or pretty-printed format.
 
+#### Install coverage
+
+    pub global activate coverage
+    
+Consider adding the `pub global run` executables directory to your path. 
+See [Running a script from your PATH](https://www.dartlang.org/tools/pub/cmd/pub-global.html#running-a-script-from-your-path)
+for more details.    
+    
 #### Collecting coverage from the VM
 
     dart --observe=NNNN script.dart
-    dart bin/collect_coverage.dart --port=NNNN -o coverage.json --resume-isolates
+    pub global run coverage:collect_coverage.dart --port=NNNN -o coverage.json --resume-isolates
+
+or if the `pub global run` executables are in your path, just
+    
+    collect_coverage.dart --port=NNNN -o coverage.json --resume-isolates    
 
 If `collect_coverage.dart` is invoked before the script from which coverage is
 to be collected, it will wait until it detects a VM observatory port to which
@@ -27,7 +39,13 @@ wait until all isolates are paused before collecting coverage.
 
     dartium --remote-debugging-port=NNNN
     # execute code in Dartium
-    dart bin/collect_coverage.dart --port=NNNN -o coverage.json
+    pub global run coverage:collect_coverage.dart --port=NNNN -o coverage.json
+
+or if the `pub global run` executables are in your path, just
+
+    collect_coverage.dart --port=NNNN -o coverage.json
+
+
 
 As noted above, `collect_coverage.dart` may be invoked before Dartium, in which
 case it will wait until it detects a Dartium remote debugging port, up to the

--- a/README.md
+++ b/README.md
@@ -28,7 +28,11 @@ for more details.
 or if the `pub global run` executables are in your path, just
     
     collect_coverage.dart --port=NNNN -o coverage.json --resume-isolates    
+    
+These previous two commands can also be combined to one 
 
+    collect_coverage.dart --port=NNNN -o coverage.json --resume-isolates --script=script.dart
+    
 If `collect_coverage.dart` is invoked before the script from which coverage is
 to be collected, it will wait until it detects a VM observatory port to which
 it can connect. An optional `--connect-timeout` may be specified (in seconds).

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: coverage
-version: 0.6.0
+version: 0.6.0+1
 author: Dart Team <misc@dartlang.org>
 description: Coverage data manipulation and formatting
 homepage: https://github.com/dart-lang/coverage
@@ -10,3 +10,6 @@ dependencies:
   http: '>=0.9.0 <2.0.0'
   logging: '>=0.9.0 <0.10.0'
   path: '>=0.9.0 <2.0.0'
+executables:
+  collect_coverage:
+  format_coverage:


### PR DESCRIPTION
added a `--script` option to make collect_coverate run the script and collect coverage information in one command.