### PR TITLE
Add support for "pub global activate"

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -3,6 +3,9 @@ version: 0.6.0
 author: Dart Team <misc@dartlang.org>
 description: Coverage data manipulation and formatting
 homepage: https://github.com/dart-lang/coverage
+executables:
+  collect_coverage:
+  format_coverage:
 environment:
   sdk: '>=1.4.0 <2.0.0'
 dependencies:


### PR DESCRIPTION
With this change, running "pub global activate" will add format_coverage and collect_coverage to PATH