### PR TITLE
Warn on missing file instead of failing.

### DIFF
--- a/lib/src/formatter.dart
+++ b/lib/src/formatter.dart
@@ -18,7 +18,13 @@ class LcovFormatter implements Formatter {
     var emitOne = (key) {
       var v = hitmap[key];
       StringBuffer entry = new StringBuffer();
-      var source = resolver.resolve(key);
+      var source;
+      try {
+        source = resolver.resolve(key);
+      } on FileSystemException catch (e) {
+        // Couldn't resolve a file
+        print('Warning: couldn\'t resolve $key');
+      }
       if (source == null) {
         return new Future.value();
       }
@@ -52,7 +58,13 @@ class PrettyPrintFormatter implements Formatter {
     var emitOne = (key) {
       var v = hitmap[key];
       var c = new Completer();
-      var uri = resolver.resolve(key);
+      var uri;
+      try {
+        uri = resolver.resolve(key);
+      } on FileSystemException catch (e) {
+        // Couldn't resolve a file
+        print('Warning: couldn\'t resolve $key');
+      }
       if (uri == null) {
         c.complete();
       } else {


### PR DESCRIPTION
If the resolver can't resolve a file path, it fails with a `FileSystemException`. I've run into scenarios when running coverage on tests in dartium where a Dart SDK path is malformed, and warning on these failed paths instead of failing altogether would be a better solution in my opinion.