### PR TITLE
Add option to restrict coverage breadth.

### DIFF
--- a/test/lcov_test.dart
+++ b/test/lcov_test.dart
@@ -38,42 +38,102 @@ void main() {
         reason: 'be careful if you modify the test file');
   });
 
-  test('format', () async {
-    var hitmap = await _getHitMap();
+  group('LcovFormatter', () {
 
-    var resolver = new Resolver(packageRoot: 'packages');
-    var formatter = new LcovFormatter(resolver);
+    test('format()', () async {
+      var hitmap = await _getHitMap();
 
-    String res = await formatter.format(hitmap);
+      var resolver = new Resolver(packageRoot: 'packages');
+      var formatter = new LcovFormatter(resolver);
 
-    expect(res, contains(p.absolute(_sampleAppPath)));
-    expect(res, contains(p.absolute(_isolateLibPath)));
-    expect(res, contains(p.absolute(p.join('lib', 'src', 'util.dart'))));
+      String res = await formatter.format(hitmap);
+
+      expect(res, contains(p.absolute(_sampleAppPath)));
+      expect(res, contains(p.absolute(_isolateLibPath)));
+      expect(res, contains(p.absolute(p.join('lib', 'src', 'util.dart'))));
+    });
+
+    test('format() includes files in reportOn list', () async {
+      var hitmap = await _getHitMap();
+
+      var resolver = new Resolver(packageRoot: 'packages');
+      var formatter = new LcovFormatter(resolver);
+
+      String res = await formatter.format(hitmap, reportOn: ['lib/', 'test/']);
+
+      expect(res, contains(p.absolute(_sampleAppPath)));
+      expect(res, contains(p.absolute(_isolateLibPath)));
+      expect(res, contains(p.absolute(p.join('lib', 'src', 'util.dart'))));
+    });
+
+    test('format() excludes files not in reportOn list', () async {
+      var hitmap = await _getHitMap();
+
+      var resolver = new Resolver(packageRoot: 'packages');
+      var formatter = new LcovFormatter(resolver);
+
+      String res = await formatter.format(hitmap, reportOn: ['lib/']);
+
+      expect(res, isNot(contains(p.absolute(_sampleAppPath))));
+      expect(res, isNot(contains(p.absolute(_isolateLibPath))));
+      expect(res, contains(p.absolute(p.join('lib', 'src', 'util.dart'))));
+    });
+
   });
 
-  test('PrettyPrintFormatter', () async {
-    var hitmap = await _getHitMap();
+  group('PrettyPrintFormatter', () {
 
-    var resolver = new Resolver(packageRoot: 'packages');
-    var formatter = new PrettyPrintFormatter(resolver, new Loader());
+    test('format()', () async {
+      var hitmap = await _getHitMap();
 
-    String res = await formatter.format(hitmap);
+      var resolver = new Resolver(packageRoot: 'packages');
+      var formatter = new PrettyPrintFormatter(resolver, new Loader());
 
-    expect(res, contains(p.absolute(_sampleAppPath)));
-    expect(res, contains(p.absolute(_isolateLibPath)));
-    expect(res, contains(p.absolute(p.join('lib', 'src', 'util.dart'))));
+      String res = await formatter.format(hitmap);
 
-    // be very careful if you change the test file
-    expect(res, contains("      0|  return a - b;"));
+      expect(res, contains(p.absolute(_sampleAppPath)));
+      expect(res, contains(p.absolute(_isolateLibPath)));
+      expect(res, contains(p.absolute(p.join('lib', 'src', 'util.dart'))));
 
-    expect(res, contains('      1|  return _withTimeout(() async {'),
-        reason: 'be careful if you change lib/src/util.dart');
+      // be very careful if you change the test file
+      expect(res, contains("      0|  return a - b;"));
 
-    var hitLineRegexp = new RegExp(r'\s+(\d+)\|  return a \+ b;');
-    var match = hitLineRegexp.allMatches(res).single;
+      expect(res, contains('      1|  return _withTimeout(() async {'),
+      reason: 'be careful if you change lib/src/util.dart');
 
-    var hitCount = int.parse(match[1]);
-    expect(hitCount, greaterThanOrEqualTo(1));
+      var hitLineRegexp = new RegExp(r'\s+(\d+)\|  return a \+ b;');
+      var match = hitLineRegexp.allMatches(res).single;
+
+      var hitCount = int.parse(match[1]);
+      expect(hitCount, greaterThanOrEqualTo(1));
+    });
+
+    test('format() includes files in reportOn list', () async {
+      var hitmap = await _getHitMap();
+
+      var resolver = new Resolver(packageRoot: 'packages');
+      var formatter = new PrettyPrintFormatter(resolver, new Loader());
+
+      String res = await formatter.format(hitmap, reportOn: ['lib/', 'test/']);
+
+      expect(res, contains(p.absolute(_sampleAppPath)));
+      expect(res, contains(p.absolute(_isolateLibPath)));
+      expect(res, contains(p.absolute(p.join('lib', 'src', 'util.dart'))));
+    });
+
+    test('format() excludes files not in reportOn list', () async {
+      var hitmap = await _getHitMap();
+
+      var resolver = new Resolver(packageRoot: 'packages');
+      var formatter = new PrettyPrintFormatter(resolver, new Loader());
+
+      String res = await formatter.format(hitmap, reportOn: ['lib/']);
+
+      expect(res, isNot(contains(p.absolute(_sampleAppPath))));
+      expect(res, isNot(contains(p.absolute(_isolateLibPath))));
+      expect(res, contains(p.absolute(p.join('lib', 'src', 'util.dart'))));
+    });
+
   });
 }
 


### PR DESCRIPTION
Currently there is no way to specify which files you actually want coverage on during the `collect_coverage` step. As a workaround, I've added a `report-on` option to the `format_coverage` that takes one or many paths specifying the files/directories for which coverage should actually be formatted and included in the final lcov report.

Example usage:
```
pub run coverage:format_coverage -l --package-root=packages -i coverage.json -o coverage.lcov --report-on=lib/
```

The `coverage.lcov` output will then only include coverage data for files within the `lib/` directory.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/dart-lang/coverage/67)
<!-- Reviewable:end -->
