### PR TITLE
No longer emit SDK coverage unless explicitly requested via --sdk-root.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+###0.7.0
+
+ * `format_coverage` no longer emits SDK coverage unless --sdk-root is set
+   explicitly.
+
 ###0.6.5
 
  * Fixed early collection bug when --wait-paused is set.

--- a/bin/format_coverage.dart
+++ b/bin/format_coverage.dart
@@ -114,17 +114,12 @@ Environment parseArgs(List<String> arguments) {
   }
 
   env.sdkRoot = args['sdk-root'];
-  if (env.sdkRoot == null) {
-    if (Platform.environment.containsKey('DART_SDK')) {
-      env.sdkRoot =
-          join(absolute(normalize(Platform.environment['DART_SDK'])), 'lib');
+  if (env.sdkRoot != null) {
+    env.sdkRoot = normalize(join(absolute(env.sdkRoot), 'lib'));
+    if (!FileSystemEntity.isDirectorySync(env.sdkRoot)) {
+      fail('Provided SDK root "${args["sdk-root"]}" is not a valid SDK '
+          'top-level directory');
     }
-  } else {
-    env.sdkRoot = join(absolute(normalize(env.sdkRoot)), 'lib');
-  }
-  if ((env.sdkRoot != null) && !FileSystemEntity.isDirectorySync(env.sdkRoot)) {
-    fail('Provided SDK root "${args["sdk-root"]}" is not a valid SDK '
-        'top-level directory');
   }
 
   env.pkgRoot = args['package-root'];


### PR DESCRIPTION


<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/dart-lang/coverage/92)
<!-- Reviewable:end -->
