### PR TITLE
expose lib/src/collect

### DIFF
--- a/lib/coverage.dart
+++ b/lib/coverage.dart
@@ -3,3 +3,4 @@ library coverage;
 export 'src/hitmap.dart';
 export 'src/formatter.dart';
 export 'src/resolver.dart';
+export 'src/collect.dart';

--- a/test/collect_coverage_api_test.dart
+++ b/test/collect_coverage_api_test.dart
@@ -1,0 +1,81 @@
+// Copyright (c) 2015, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+library coverage.test.collect_coverage_api_test;
+
+import 'dart:async';
+import 'dart:io';
+
+import 'package:coverage/coverage.dart';
+import 'package:path/path.dart' as p;
+import 'package:test/test.dart';
+
+final _sampleAppPath = p.join('test', 'test_files', 'test_app.dart');
+final _isolateLibPath = p.join('test', 'test_files', 'test_app_isolate.dart');
+
+final _sampleAppFileUri = p.toUri(p.absolute(_sampleAppPath)).toString();
+final _isolateLibFileUri = p.toUri(p.absolute(_isolateLibPath)).toString();
+
+const _timeout = const Duration(seconds: 5);
+
+void main() {
+  test('collect_coverage_api', () async {
+    var json = await _getCoverageResult();
+
+    expect(json.keys, unorderedEquals(['type', 'coverage']));
+
+    expect(json, containsPair('type', 'CodeCoverage'));
+
+    var coverage = json['coverage'] as List;
+    expect(coverage, isNotEmpty);
+
+    var sources = coverage.fold(<String, dynamic>{}, (Map map, Map value) {
+      var sourceUri = value['source'];
+
+      map.putIfAbsent(sourceUri, () => <Map>[]).add(value);
+
+      return map;
+    });
+
+    for (var sampleCoverageData in sources[_sampleAppFileUri]) {
+      expect(sampleCoverageData['hits'], isNotEmpty);
+    }
+
+    for (var sampleCoverageData in sources[_isolateLibFileUri]) {
+      expect(sampleCoverageData['hits'], isNotEmpty);
+    }
+  });
+}
+
+Map _coverageData;
+
+Future<Map> _getCoverageResult() async {
+  if (_coverageData == null) {
+    _coverageData = await _collectCoverage();
+  }
+  return _coverageData;
+}
+
+Future<Map> _collectCoverage() async {
+  // need to find an open port
+  var socket = await ServerSocket.bind(InternetAddress.ANY_IP_V4, 0);
+  int openPort = socket.port;
+  await socket.close();
+
+  // run the sample app, with the right flags
+  var sampleProcFuture = Process
+      .run('dart', [
+    '--enable-vm-service=$openPort',
+    '--pause_isolates_on_exit',
+    _sampleAppPath
+  ])
+      .timeout(_timeout, onTimeout: () {
+    throw 'We timed out waiting for the sample app to finish.';
+  });
+
+  var result = collect('127.0.0.1', openPort, true, false, timeout: _timeout);
+  await sampleProcFuture;
+
+  return result;
+}

--- a/test/test_all.dart
+++ b/test/test_all.dart
@@ -1,11 +1,13 @@
 import 'package:test/test.dart';
 
 import 'collect_coverage_test.dart' as collect_coverage;
+import 'collect_coverage_test.dart' as collect_coverage_api;
 import 'lcov_test.dart' as lcov;
 import 'util_test.dart' as util;
 
 void main() {
   group('collect_coverage', collect_coverage.main);
+  group('collect_coverage_api', collect_coverage_api.main);
   group('lcov', lcov.main);
   group('util', util.main);
 }


### PR DESCRIPTION
I had the impression `true` for `wait` should work here https://github.com/dart-lang/coverage/compare/master...bwu-dart-contributing:master#diff-43df7f33c6ee2745896deffe2f16bfb4R77 but it didn't. Maybe I just don't understand how this is supposed to work.

I created a new test file even though a lot of code is just duplicated.
I thought it would be too messy if I put it in the `collect_coverage_test` file as well.

Some tests in `collect_coverage_test.dart` also the test I added only works half of the time on my machine even with much higher timeout. 
I wasted half of this day trying to make this work in a package of mine (didn't work reliable with the code before or after #39)

![testout](https://cloud.githubusercontent.com/assets/405837/8014809/0fffa5c0-0bd4-11e5-90c9-441a270031e9.jpg)

The attached file is the test output (actually a .txt file but GitHub won't let me attach it this way).