### PR TITLE
Fix change of eventType -> kind in Dart 1.11-dev.0.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+###0.7.1
+
+ * Added `collect` top-level method.
+ 
+ * Updated support for latest `0.11.0` dev build.
+ 
+ * Replaced `ServiceEvent.eventType` with `ServiceEvent.kind`.
+   *  `ServiceEvent.eventType` is deprecated and will be removed in `0.8`.
+
 ###0.7.0
 
  * `format_coverage` no longer emits SDK coverage unless --sdk-root is set

--- a/lib/src/devtools.dart
+++ b/lib/src/devtools.dart
@@ -128,7 +128,7 @@ class Isolate {
   final bool pauseOnExit;
   final ServiceEvent pauseEvent;
   bool get paused =>
-      pauseOnExit && pauseEvent != null && pauseEvent.eventType == 'PauseExit';
+      pauseOnExit && pauseEvent != null && pauseEvent.kind == 'PauseExit';
 
   Isolate(this.id, this.name, this.pauseOnExit, this.pauseEvent);
 
@@ -137,13 +137,23 @@ class Isolate {
 }
 
 class ServiceEvent {
-  final String eventType;
+  final String kind;
   final IsolateRef isolate;
 
-  ServiceEvent(this.eventType, this.isolate);
+  @deprecated('Will be removed in 0.8')
+  String get eventType => kind;
 
-  factory ServiceEvent.fromJson(json) => new ServiceEvent(
-      json['eventType'], new IsolateRef.fromJson(json['isolate']));
+  ServiceEvent(this.kind, this.isolate);
+
+  factory ServiceEvent.fromJson(Map json) {
+    // TODO(kevmoo) Keep around until 1.11 is stable
+    // https://github.com/dart-lang/coverage/issues/91
+    // 'kind' is the key for >= 1.11-dev.5.0.
+    // 'eventType' is for older versions
+    var kind = json.containsKey('kind') ? json['kind'] : json['eventType'];
+
+    return new ServiceEvent(kind, new IsolateRef.fromJson(json['isolate']));
+  }
 }
 
 class CodeCoverage {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: coverage
-version: 0.7.0
+version: 0.7.1
 author: Dart Team <misc@dartlang.org>
 description: Coverage data manipulation and formatting
 homepage: https://github.com/dart-lang/coverage


### PR DESCRIPTION
Call this urgent. We're broken on the latest VM release.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/dart-lang/coverage/96)
<!-- Reviewable:end -->
