### PR TITLE
Skip over evaluate:source ranges.

### DIFF
--- a/lib/src/collect.dart
+++ b/lib/src/collect.dart
@@ -84,6 +84,9 @@ Future<List> _getCoverageJson(
   // script uri -> { line -> hit count }
   var hitMaps = <Uri, Map<int, int>>{};
   for (var range in report.ranges) {
+    // Not returned in scripts section of source report.
+    if (range.script.uri.scheme == 'evaluate') continue;
+
     hitMaps.putIfAbsent(range.script.uri, () => <int, int>{});
     var hitMap = hitMaps[range.script.uri];
     var script = scripts[range.script.uri];

--- a/test/collect_coverage_test.dart
+++ b/test/collect_coverage_test.dart
@@ -84,7 +84,7 @@ void main() {
     } finally {
       await tempDir.delete(recursive: true);
     }
-  }, timeout: new Timeout.factor(2));
+  });
 }
 
 String _coverageData;


### PR DESCRIPTION
These aren't returned in the scripts section of the source report. Note: such
ranges will likely not be part of the source report in future VM versions, at
which time this check could be eliminated and the minimum SDK version bumped.