### PR TITLE
Increase timeout for parseCoverage test.

### DIFF
--- a/test/collect_coverage_test.dart
+++ b/test/collect_coverage_test.dart
@@ -84,7 +84,7 @@ void main() {
     } finally {
       await tempDir.delete(recursive: true);
     }
-  });
+  }, timeout: new Timeout.factor(2));
 }
 
 String _coverageData;


### PR DESCRIPTION
Between spawning processes, disk I/O, and use of isolates, this test is timing
out relatively frequently on slower hardware.