### PR TITLE
Reduce parseCoverage timeout to default.

### DIFF
--- a/test/collect_coverage_test.dart
+++ b/test/collect_coverage_test.dart
@@ -84,7 +84,7 @@ void main() {
     } finally {
       await tempDir.delete(recursive: true);
     }
-  }, timeout: new Timeout.factor(2));
+  });
 }
 
 String _coverageData;


### PR DESCRIPTION
With the elimination of isolates in parseCoverage (30c1b9a), the longer timeout
is no longer needed for slower machines -- at least reasonable ones :)