### PR TITLE
Bazel: Resolve http(s) URIs that don't contain 'packages' path segment.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
-## 0.7.7
+## 0.7.7-dev
 
+ * Add fallback URI resolution for Bazel http(s) URIs that don't contain a
+   `packages` path component.
 
 ## 0.7.6
 

--- a/lib/src/resolver.dart
+++ b/lib/src/resolver.dart
@@ -100,7 +100,8 @@ class BazelResolver extends Resolver {
     }
     if (uri.startsWith(FILE_PREFIX)) {
       var runfilesPathSegment = '$RUNFILES_SUFFIX/$workspacePath';
-      runfilesPathSegment = runfilesPathSegment.replaceAll(new RegExp(r'/*$'), '/');
+      runfilesPathSegment =
+          runfilesPathSegment.replaceAll(new RegExp(r'/*$'), '/');
       var runfilesPos = uri.indexOf(runfilesPathSegment);
       if (runfilesPos >= 0) {
         int pathStart = runfilesPos + runfilesPathSegment.length;
@@ -109,24 +110,25 @@ class BazelResolver extends Resolver {
       return null;
     }
     if (uri.startsWith(HTTPS_PREFIX)) {
-      uri = uri.substring(HTTPS_PREFIX.length);
-      int packagesPos = uri.indexOf(PACKAGES_SEGMENT);
-      if (packagesPos >= 0) {
-        return _resolveBazelPackage(uri.substring(packagesPos + PACKAGES_SEGMENT.length));
-      }
-      return uri;
+      return _extractHttpPath(uri, HTTPS_PREFIX);
     }
     if (uri.startsWith(HTTP_PREFIX)) {
-      uri = uri.substring(HTTP_PREFIX.length);
-      int packagesPos = uri.indexOf(PACKAGES_SEGMENT);
-      if (packagesPos >= 0) {
-        return _resolveBazelPackage(uri.substring(packagesPos + PACKAGES_SEGMENT.length));
-      }
-      return uri;
+      return _extractHttpPath(uri, HTTP_PREFIX);
     }
     // We cannot deal with anything else.
     failed.add(uri);
     return null;
+  }
+
+  String _extractHttpPath(String uri, String prefix) {
+    uri = uri.substring(prefix.length);
+    int packagesPos = uri.indexOf(PACKAGES_SEGMENT);
+    if (packagesPos >= 0) {
+      return _resolveBazelPackage(
+          uri.substring(packagesPos + PACKAGES_SEGMENT.length));
+    }
+    int pathPos = uri.indexOf('/');
+    return pathPos >= 0 ? uri.substring(pathPos + 1) : uri;
   }
 
   String _resolveBazelPackage(String uriPath) {

--- a/test/resolver_test.dart
+++ b/test/resolver_test.dart
@@ -3,38 +3,94 @@ import 'package:test/test.dart';
 
 main() {
   group('Bazel resolver', () {
-      const workspace = 'foo';
-      final resolver = new BazelResolver(workspacePath: workspace);
+    const workspace = 'foo';
+    final resolver = new BazelResolver(workspacePath: workspace);
 
-      test('does not resolve SDK URIs', () {
-        expect(resolver.resolve('dart:convert'), null);
-      });
+    test('does not resolve SDK URIs', () {
+      expect(resolver.resolve('dart:convert'), null);
+    });
 
-      test('resolves third-party package URIs', () {
-        expect(resolver.resolve('package:foo/bar.dart'), 'third_party/dart/foo/lib/bar.dart');
-        expect(resolver.resolve('package:foo/src/bar.dart'), 'third_party/dart/foo/lib/src/bar.dart');
-      });
+    test('resolves third-party package URIs', () {
+      expect(resolver.resolve('package:foo/bar.dart'),
+          'third_party/dart/foo/lib/bar.dart');
+      expect(resolver.resolve('package:foo/src/bar.dart'),
+          'third_party/dart/foo/lib/src/bar.dart');
+    });
 
-      test('resolves non-third-party package URIs', () {
-        expect(resolver.resolve('package:foo.bar/baz.dart'), 'foo/bar/lib/baz.dart');
-        expect(resolver.resolve('package:foo.bar/src/baz.dart'), 'foo/bar/lib/src/baz.dart');
-      });
+    test('resolves non-third-party package URIs', () {
+      expect(
+          resolver.resolve('package:foo.bar/baz.dart'), 'foo/bar/lib/baz.dart');
+      expect(resolver.resolve('package:foo.bar/src/baz.dart'),
+          'foo/bar/lib/src/baz.dart');
+    });
 
-      test('resolves file URIs', () {
-        expect(resolver.resolve('file://x/y/z.runfiles/$workspace/foo/bar/lib/baz.dart'), 'foo/bar/lib/baz.dart');
-        expect(resolver.resolve('file://x/y/z.runfiles/$workspace/foo/bar/lib/src/baz.dart'), 'foo/bar/lib/src/baz.dart');
-      });
+    test('resolves file URIs', () {
+      expect(
+          resolver
+              .resolve('file://x/y/z.runfiles/$workspace/foo/bar/lib/baz.dart'),
+          'foo/bar/lib/baz.dart');
+      expect(
+          resolver.resolve(
+              'file://x/y/z.runfiles/$workspace/foo/bar/lib/src/baz.dart'),
+          'foo/bar/lib/src/baz.dart');
+    });
 
-      test('resolves HTTPS URIs', () {
-        expect(resolver.resolve('https://a/b/packages/foo/bar.dart'), 'third_party/dart/foo/lib/bar.dart');
-        expect(resolver.resolve('https://a/b/packages/foo/src/bar.dart'), 'third_party/dart/foo/lib/src/bar.dart');
-        expect(resolver.resolve('https://a/b/packages/foo.bar/baz.dart'), 'foo/bar/lib/baz.dart');
-        expect(resolver.resolve('https://a/b/packages/foo.bar/src/baz.dart'), 'foo/bar/lib/src/baz.dart');
-      });
+    test('resolves HTTPS URIs containing /packages/', () {
+      expect(resolver.resolve('https://host:8080/a/b/packages/foo/bar.dart'),
+          'third_party/dart/foo/lib/bar.dart');
+      expect(
+          resolver.resolve('https://host:8080/a/b/packages/foo/src/bar.dart'),
+          'third_party/dart/foo/lib/src/bar.dart');
+      expect(
+          resolver.resolve('https://host:8080/a/b/packages/foo.bar/baz.dart'),
+          'foo/bar/lib/baz.dart');
+      expect(
+          resolver
+              .resolve('https://host:8080/a/b/packages/foo.bar/src/baz.dart'),
+          'foo/bar/lib/src/baz.dart');
+    });
 
-      test('resolves HTTP URIs', () {
-        expect(resolver.resolve('http://a/b/packages/foo.bar/baz.dart'), 'foo/bar/lib/baz.dart');
-        expect(resolver.resolve('http://a/b/packages/foo.bar/src/baz.dart'), 'foo/bar/lib/src/baz.dart');
-      });
+    test('resolves HTTP URIs containing /packages/', () {
+      expect(resolver.resolve('http://host:8080/a/b/packages/foo/bar.dart'),
+          'third_party/dart/foo/lib/bar.dart');
+      expect(resolver.resolve('http://host:8080/a/b/packages/foo/src/bar.dart'),
+          'third_party/dart/foo/lib/src/bar.dart');
+      expect(resolver.resolve('http://host:8080/a/b/packages/foo.bar/baz.dart'),
+          'foo/bar/lib/baz.dart');
+      expect(
+          resolver
+              .resolve('http://host:8080/a/b/packages/foo.bar/src/baz.dart'),
+          'foo/bar/lib/src/baz.dart');
+    });
+
+    test('resolves HTTPS URIs without /packages/', () {
+      expect(
+          resolver
+              .resolve('https://host:8080/third_party/dart/foo/lib/bar.dart'),
+          'third_party/dart/foo/lib/bar.dart');
+      expect(
+          resolver.resolve(
+              'https://host:8080/third_party/dart/foo/lib/src/bar.dart'),
+          'third_party/dart/foo/lib/src/bar.dart');
+      expect(resolver.resolve('https://host:8080/foo/lib/bar.dart'),
+          'foo/lib/bar.dart');
+      expect(resolver.resolve('https://host:8080/foo/lib/src/bar.dart'),
+          'foo/lib/src/bar.dart');
+    });
+
+    test('resolves HTTP URIs without /packages/', () {
+      expect(
+          resolver
+              .resolve('http://host:8080/third_party/dart/foo/lib/bar.dart'),
+          'third_party/dart/foo/lib/bar.dart');
+      expect(
+          resolver.resolve(
+              'http://host:8080/third_party/dart/foo/lib/src/bar.dart'),
+          'third_party/dart/foo/lib/src/bar.dart');
+      expect(resolver.resolve('http://host:8080/foo/lib/bar.dart'),
+          'foo/lib/bar.dart');
+      expect(resolver.resolve('http://host:8080/foo/lib/src/bar.dart'),
+          'foo/lib/src/bar.dart');
+    });
   });
 }


### PR DESCRIPTION
In case `/packages/` is not found in the URI, fall back to simply returning the
URL path.