### PR TITLE
Collect packages from packageRoot/.packages in Resolver

### DIFF
--- a/lib/src/resolver.dart
+++ b/lib/src/resolver.dart
@@ -14,8 +14,9 @@ class Resolver {
   final List<String> failed = [];
   Map<String, Uri> _packages;
 
-  Resolver({String packagesPath, this.packageRoot, this.sdkRoot})
-      : packagesPath = packagesPath,
+  Resolver({String packagesPath, String packageRoot, this.sdkRoot})
+      : packageRoot = packageRoot,
+        packagesPath = packagesPath != null ? packagesPath : packageRoot + "/.packages",
         _packages = packagesPath != null ? _parsePackages(packagesPath) : null;
 
   /// Returns the absolute path wrt. to the given environment or null, if the


### PR DESCRIPTION
Hello.
I'm not sure if this a bug in `coverage` or something wrong in my project, but `format_coverage` can't resolve `package:` uris for my project, passed as package-root, because `Resolver::_packages` aren't initialized if `--package-root` option is given.

I've made a patch, that makes Resolver parse `<package-root>/.packages` file if `packageRoot` is specified. Now `format_coverage` outputs coverage info for my project.
