### PR TITLE
Add a basePath argument to the LCOV formatter

### DIFF
--- a/lib/src/formatter.dart
+++ b/lib/src/formatter.dart
@@ -3,6 +3,8 @@ library coverage.formatter;
 import 'dart:async';
 import 'dart:io';
 
+import 'package:path/path.dart' as p;
+
 import 'resolver.dart';
 
 abstract class Formatter {
@@ -28,7 +30,9 @@ class LcovFormatter implements Formatter {
   LcovFormatter(this.resolver);
 
   Future<String> format(Map hitmap,
-      {List<String> reportOn, bool pathFilter(String path)}) async {
+      {List<String> reportOn,
+      bool pathFilter(String path),
+      String basePath}) async {
     pathFilter = _getFilter(pathFilter, reportOn);
 
     var buf = new StringBuffer();
@@ -41,6 +45,10 @@ class LcovFormatter implements Formatter {
 
       if (!pathFilter(source)) {
         continue;
+      }
+
+      if (basePath != null) {
+        source = p.relative(source, from: basePath);
       }
 
       buf.write('SF:${source}\n');

--- a/test/lcov_test.dart
+++ b/test/lcov_test.dart
@@ -78,6 +78,19 @@ void main() {
       expect(res, isNot(contains(p.absolute(_isolateLibPath))));
       expect(res, contains(p.absolute(p.join('lib', 'src', 'util.dart'))));
     });
+
+    test('format() uses paths relative to basePath', () async {
+      var hitmap = await _getHitMap();
+
+      var resolver = new Resolver(packageRoot: 'packages');
+      var formatter = new LcovFormatter(resolver);
+
+      String res = await formatter.format(hitmap, basePath: p.absolute('lib'));
+
+      expect(
+          res, isNot(contains(p.absolute(p.join('lib', 'src', 'util.dart')))));
+      expect(res, contains(p.join('src', 'util.dart')));
+    });
   });
 
   group('PrettyPrintFormatter', () {


### PR DESCRIPTION
The resulting LCOV file will use paths relative to this base path.