### PR TITLE
Extract format reportOn and basePath parameters to constructor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.8.0
+ * Moved `Formatter.format` parameters `reportOn` and `basePath` to
+   constructor. Eliminated `pathFilter` parameter.
+
 ## 0.7.9
 
  * `format_coverage`: add `--base-directory` option. Source paths in

--- a/bin/format_coverage.dart
+++ b/bin/format_coverage.dart
@@ -56,12 +56,12 @@ main(List<String> arguments) async {
                      sdkRoot: env.sdkRoot);
   var loader = new Loader();
   if (env.prettyPrint) {
-    output = await new PrettyPrintFormatter(resolver, loader)
-        .format(hitmap, reportOn: env.reportOn);
+    output = await new PrettyPrintFormatter(resolver, loader, reportOn: env.reportOn)
+        .format(hitmap);
   } else {
     assert(env.lcov);
-    output = await new LcovFormatter(resolver)
-        .format(hitmap, reportOn: env.reportOn, basePath: env.baseDirectory);
+    output = await new LcovFormatter(resolver, reportOn: env.reportOn, basePath: env.baseDirectory)
+        .format(hitmap);
   }
 
   env.output.write(output);

--- a/test/lcov_test.dart
+++ b/test/lcov_test.dart
@@ -57,9 +57,9 @@ void main() {
       var hitmap = await _getHitMap();
 
       var resolver = new Resolver(packageRoot: 'packages');
-      var formatter = new LcovFormatter(resolver);
+      var formatter = new LcovFormatter(resolver, reportOn: ['lib/', 'test/']);
 
-      String res = await formatter.format(hitmap, reportOn: ['lib/', 'test/']);
+      String res = await formatter.format(hitmap);
 
       expect(res, contains(p.absolute(_sampleAppPath)));
       expect(res, contains(p.absolute(_isolateLibPath)));
@@ -70,9 +70,9 @@ void main() {
       var hitmap = await _getHitMap();
 
       var resolver = new Resolver(packageRoot: 'packages');
-      var formatter = new LcovFormatter(resolver);
+      var formatter = new LcovFormatter(resolver, reportOn: ['lib/']);
 
-      String res = await formatter.format(hitmap, reportOn: ['lib/']);
+      String res = await formatter.format(hitmap);
 
       expect(res, isNot(contains(p.absolute(_sampleAppPath))));
       expect(res, isNot(contains(p.absolute(_isolateLibPath))));
@@ -83,9 +83,9 @@ void main() {
       var hitmap = await _getHitMap();
 
       var resolver = new Resolver(packageRoot: 'packages');
-      var formatter = new LcovFormatter(resolver);
+      var formatter = new LcovFormatter(resolver, basePath: p.absolute('lib'));
 
-      String res = await formatter.format(hitmap, basePath: p.absolute('lib'));
+      String res = await formatter.format(hitmap);
 
       expect(
           res, isNot(contains(p.absolute(p.join('lib', 'src', 'util.dart')))));
@@ -123,9 +123,10 @@ void main() {
       var hitmap = await _getHitMap();
 
       var resolver = new Resolver(packageRoot: 'packages');
-      var formatter = new PrettyPrintFormatter(resolver, new Loader());
+      var formatter = new PrettyPrintFormatter(resolver, new Loader(),
+          reportOn: ['lib/', 'test/']);
 
-      String res = await formatter.format(hitmap, reportOn: ['lib/', 'test/']);
+      String res = await formatter.format(hitmap);
 
       expect(res, contains(p.absolute(_sampleAppPath)));
       expect(res, contains(p.absolute(_isolateLibPath)));
@@ -136,9 +137,10 @@ void main() {
       var hitmap = await _getHitMap();
 
       var resolver = new Resolver(packageRoot: 'packages');
-      var formatter = new PrettyPrintFormatter(resolver, new Loader());
+      var formatter =
+          new PrettyPrintFormatter(resolver, new Loader(), reportOn: ['lib/']);
 
-      String res = await formatter.format(hitmap, reportOn: ['lib/']);
+      String res = await formatter.format(hitmap);
 
       expect(res, isNot(contains(p.absolute(_sampleAppPath))));
       expect(res, isNot(contains(p.absolute(_isolateLibPath))));


### PR DESCRIPTION
This allows pre-configured Formatter objects to be passed to APIs.