### PR TITLE
Default to checked mode in runAndCollect

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Unreleased
+
+ * BREAKING CHANGE: `runAndCollect` now defaults to running in checked mode.
+
 ## 0.8.1
 
  * Added optional `checked` parameter to `runAndCollect` to run in checked

--- a/lib/src/run_and_collect.dart
+++ b/lib/src/run_and_collect.dart
@@ -12,7 +12,7 @@ import 'util.dart';
 
 Future<Map> runAndCollect(String scriptPath,
     {List<String> scriptArgs,
-    bool checked: false,
+    bool checked: true,
     String packageRoot,
     Duration timeout}) async {
   var openPort = await getOpenPort();


### PR DESCRIPTION
In almost all cases, developers should be defaulting to checked mode
when running tests. This change brings behaviour in line with the
package:test default.