### PR TITLE
Reduce memory consumption during coverage collection

### DIFF
--- a/lib/src/collect.dart
+++ b/lib/src/collect.dart
@@ -48,7 +48,6 @@ Future<Map<String, dynamic>> collect(
     await vmService.close();
   }
 }
-}
 
 Future<Map<String, dynamic>> _getAllCoverage(VMServiceClient service, {StringSink outputBuffer}) async {
   var vm = await service.getVM();

--- a/lib/src/collect.dart
+++ b/lib/src/collect.dart
@@ -61,7 +61,7 @@ Future<Map<String, dynamic>> _getAllCoverage(VMServiceClient service, {StringSin
     await isolateRef.resume();
     counter ++;
   }
-  return {'type': 'CodeCoverage', 'coverage': allCoverage};
+  return <String, dynamic>{'type': 'CodeCoverage', 'coverage': allCoverage};
 }
 
 Future _resumeIsolates(VMServiceClient service) async {
@@ -93,7 +93,7 @@ Future<List<Map<String, dynamic>>> _getCoverageJson(
     VMServiceClient service, VMSourceReport report) async {
   var scriptRefs = report.ranges.map((r) => r.script).toSet();
   var scripts = new Map<Uri, VMScript>.fromIterable(
-      await Future.wait(scriptRefs.map((ref) => ref.load()).toList()),
+      await Future.wait<VMScript>(scriptRefs.map((ref) => ref.load()).toList()),
       key: (VMScript s) => s.uri);
 
   // script uri -> { line -> hit count }

--- a/lib/src/collect.dart
+++ b/lib/src/collect.dart
@@ -45,21 +45,24 @@ Future<Map<String, dynamic>> collect(
   }
 }
 
-Future<Map<String, dynamic>> _getAllCoverage(VMServiceClient service, {StringSink outputSink}) async {
+Future<Map<String, dynamic>> _getAllCoverage(VMServiceClient service,
+    {StringSink outputSink}) async {
   var vm = await service.getVM();
   var allCoverage = <Map<String, dynamic>>[];
 
   var counter = 0;
   var total = vm.isolates.length;
   for (var isolateRef in vm.isolates) {
-    outputSink?.writeln("Collecting coverage for ${isolateRef.name} (${counter + 1}/$total)...");
+    outputSink?.writeln(
+        "Collecting coverage for ${isolateRef.name} (${counter + 1}/$total)...");
     var isolate = await isolateRef.load();
     var report = await isolate.getSourceReport(forceCompile: true);
     var coverage = await _getCoverageJson(service, report);
     allCoverage.addAll(coverage);
-    outputSink?.writeln("Coverage collected for ${isolateRef.name}, resuming termination.");
+    outputSink?.writeln(
+        "Coverage collected for ${isolateRef.name}, resuming termination.");
     await isolateRef.resume();
-    counter ++;
+    counter++;
   }
   return <String, dynamic>{'type': 'CodeCoverage', 'coverage': allCoverage};
 }

--- a/lib/src/collect.dart
+++ b/lib/src/collect.dart
@@ -37,11 +37,7 @@ Future<Map<String, dynamic>> collect(
     }
 
     return await _getAllCoverage(vmService, outputBuffer: outputBuffer);
-  } catch (e, st) {
-    outputBuffer?.writeln("$e");
-    outputBuffer?.writeln("$st");
-  }
-  finally {
+  } finally {
     if (resume) {
       await _resumeIsolates(vmService);
     }

--- a/lib/src/collect.dart
+++ b/lib/src/collect.dart
@@ -67,10 +67,12 @@ Future<Map<String, dynamic>> _getAllCoverage(VMServiceClient service, {StringSin
 Future _resumeIsolates(VMServiceClient service) async {
   var vm = await service.getVM();
   for (var isolateRef in vm.isolates) {
-    var isolate = await isolateRef.load();
-    if (isolate.isPaused) {
-      await isolateRef.resume();
-    }
+    try {
+      var isolate = await isolateRef.load();
+      if (isolate.isPaused) {
+        await isolateRef.resume();
+      }
+    } on VMSentinelException {}
   }
 }
 

--- a/lib/src/collect.dart
+++ b/lib/src/collect.dart
@@ -37,12 +37,17 @@ Future<Map<String, dynamic>> collect(
     }
 
     return await _getAllCoverage(vmService, outputBuffer: outputBuffer);
-  } finally {
+  } catch (e, st) {
+    outputBuffer?.writeln("$e");
+    outputBuffer?.writeln("$st");
+  }
+  finally {
     if (resume) {
       await _resumeIsolates(vmService);
     }
     await vmService.close();
   }
+}
 }
 
 Future<Map<String, dynamic>> _getAllCoverage(VMServiceClient service, {StringSink outputBuffer}) async {

--- a/lib/src/run_and_collect.dart
+++ b/lib/src/run_and_collect.dart
@@ -52,10 +52,10 @@ Future<Map<String, dynamic>> runAndCollect(String scriptPath,
   outputSink?.writeln("Waiting for Observatory...");
   var serviceUri = await serviceUriCompleter.future;
 
-
   Map<String, dynamic> coverage;
   try {
-    coverage = await collect(serviceUri, true, true, timeout: timeout, outputSink: outputSink);
+    coverage = await collect(serviceUri, true, true,
+        timeout: timeout, outputSink: outputSink);
   } finally {
     await process.stderr.drain<List<int>>();
   }

--- a/lib/src/run_and_collect.dart
+++ b/lib/src/run_and_collect.dart
@@ -16,7 +16,7 @@ Future<Map<String, dynamic>> runAndCollect(String scriptPath,
     bool checked: true,
     String packageRoot,
     Duration timeout,
-    StringSink outputBuffer}) async {
+    StringSink outputSink}) async {
   var dartArgs = [
     '--enable-vm-service',
     '--pause_isolates_on_exit',
@@ -42,20 +42,20 @@ Future<Map<String, dynamic>> runAndCollect(String scriptPath,
       .transform(UTF8.decoder)
       .transform(const LineSplitter())
       .listen((line) {
-    outputBuffer?.writeln("$line");
+    outputSink?.writeln("$line");
     var uri = extractObservatoryUri(line);
     if (uri != null) {
       serviceUriCompleter.complete(uri);
     }
   });
 
-  outputBuffer?.writeln("Waiting for Observatory...");
+  outputSink?.writeln("Waiting for Observatory...");
   var serviceUri = await serviceUriCompleter.future;
 
 
   Map<String, dynamic> coverage;
   try {
-    coverage = await collect(serviceUri, true, true, timeout: timeout, outputBuffer: outputBuffer);
+    coverage = await collect(serviceUri, true, true, timeout: timeout, outputSink: outputSink);
   } finally {
     await process.stderr.drain<List<int>>();
   }

--- a/test/collect_coverage_api_test.dart
+++ b/test/collect_coverage_api_test.dart
@@ -22,7 +22,7 @@ final _isolateLibFileUri = p.toUri(p.absolute(_isolateLibPath)).toString();
 void main() {
   test('collect_coverage_api', () async {
     Map<String, dynamic> json = await _getCoverageResult();
-    expect(json.keys, unorderedEquals(['type', 'coverage']));
+    expect(json.keys, unorderedEquals(<String>['type', 'coverage']));
     expect(json, containsPair('type', 'CodeCoverage'));
 
     List coverage = json['coverage'];

--- a/test/collect_coverage_test.dart
+++ b/test/collect_coverage_test.dart
@@ -28,7 +28,7 @@ void main() {
     // analyze the output json
     Map<String, dynamic> json = JSON.decode(resultString);
 
-    expect(json.keys, unorderedEquals(['type', 'coverage']));
+    expect(json.keys, unorderedEquals(<String>['type', 'coverage']));
     expect(json, containsPair('type', 'CodeCoverage'));
 
     List<Map<String, dynamic>> coverage = json['coverage'];

--- a/test/run_and_collect_test.dart
+++ b/test/run_and_collect_test.dart
@@ -19,7 +19,7 @@ void main() {
   test('runAndCollect', () async {
     // use runAndCollect and verify that the results match w/ running manually
     var json = await runAndCollect(testAppPath);
-    expect(json.keys, unorderedEquals(['type', 'coverage']));
+    expect(json.keys, unorderedEquals(<String>['type', 'coverage']));
     expect(json, containsPair('type', 'CodeCoverage'));
 
     List<Map> coverage = json['coverage'];


### PR DESCRIPTION
This PR looks to address challenges faced by collecting coverage on tests with a significant amount of isolate spawning. See also #184.

1. Adds optional StringSink argument to collection to allow for progress output. This is key for long-running tasks in CI that may be shutdown if no output is received for a period of time.
2. Resumes isolates immediately after their coverage has been collected. Previous strategy waited until all isolates were collected, which prevented their allocations from being released and ballooned memory consumption of to unsustainable levels on CI boxes.

This is my first jump into this package, so if I am misunderstanding something, will make the appropriate fix.