### PR TITLE
Increase SDK lower bound to >=1.21.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,8 @@
 ## 0.9.3-dev - unreleased
 
  * Strong mode fixes.
- * Rev the SDK constraint to `<2.0.0-dev.infinity`.
+ * Restrict the SDK lower version constraint to `>=1.21.0`. Required for method
+   generics.
  * Eliminate dependency on package:async.
 
 ## 0.9.2 - 2017-02-03

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -4,7 +4,7 @@ author: Dart Team <misc@dartlang.org>
 description: Coverage data manipulation and formatting
 homepage: https://github.com/dart-lang/coverage
 environment:
-  sdk: '>=1.16.0 <2.0.0'
+  sdk: '>=1.21.0 <2.0.0'
 dependencies:
   args: '>=0.12.1 <1.0.0'
   logging: '>=0.9.0 <0.12.0'


### PR DESCRIPTION
Support for method generics, which pacakge:coverage users, was
introduced in Dart SDK 1.21.0. Release notes:
https://github.com/dart-lang/sdk/blob/master/CHANGELOG.md#1210---2016-12-07