### PR TITLE
Test coverage for synchronous function call

### DIFF
--- a/test/collect_coverage_test.dart
+++ b/test/collect_coverage_test.dart
@@ -57,7 +57,8 @@ void main() {
     expect(hitMap, contains(_sampleAppFileUri));
 
     Map<int, int> isolateFile = hitMap[_isolateLibFileUri];
-    expect(isolateFile, {12: 1, 14: 1, 15: 3, 16: 1});
+    expect(
+        isolateFile, {9: 1, 10: 1, 12: 0, 19: 1, 21: 1, 23: 1, 24: 3, 25: 1});
   });
 
   test('parseCoverage', () async {

--- a/test/run_and_collect_test.dart
+++ b/test/run_and_collect_test.dart
@@ -43,6 +43,7 @@ void main() {
     expect(hitMap, contains(_sampleAppFileUri));
 
     Map<int, int> isolateFile = hitMap[_isolateLibFileUri];
-    expect(isolateFile, {12: 1, 14: 1, 15: 3, 16: 1});
+    expect(
+        isolateFile, {9: 1, 10: 1, 12: 0, 19: 1, 21: 1, 23: 1, 24: 3, 25: 1});
   });
 }

--- a/test/test_files/test_app_isolate.dart
+++ b/test/test_files/test_app_isolate.dart
@@ -5,11 +5,20 @@
 import 'dart:io';
 import 'dart:isolate';
 
+String fooSync(int x) {
+  if (x == 42) {
+    return '*' * x;
+  }
+  return new List.generate(x, (_) => 'xyzzy').join(' ');
+}
+
 /// The number of covered lines is tested and expected to be 4.
 ///
 /// If you modify this method, you may have to update the tests!
 void isolateTask(List<dynamic> threeThings) {
   sleep(const Duration(milliseconds: 500));
+
+  fooSync(42);
 
   SendPort port = threeThings.first;
   int sum = threeThings[1] + threeThings[2];


### PR DESCRIPTION
Adds a test to verify expected coverage is generated for a synchronous
function with two branches, only one of which is executed.