### PR TITLE
Test coverage for async function call

### DIFF
--- a/test/collect_coverage_test.dart
+++ b/test/collect_coverage_test.dart
@@ -57,8 +57,23 @@ void main() {
     expect(hitMap, contains(_sampleAppFileUri));
 
     Map<int, int> isolateFile = hitMap[_isolateLibFileUri];
-    expect(
-        isolateFile, {9: 1, 10: 1, 12: 0, 19: 1, 21: 1, 23: 1, 24: 3, 25: 1});
+    expect(isolateFile, {
+      10: 1,
+      11: 1,
+      13: 0,
+      17: 1,
+      18: 1,
+      20: 0,
+      // TODO(cbracken) remove line 21 coverage expectation when fixed:
+      // https://github.com/dart-lang/coverage/issues/196
+      21: 0,
+      27: 1,
+      29: 1,
+      30: 2,
+      31: 1,
+      32: 3,
+      33: 1,
+    });
   });
 
   test('parseCoverage', () async {

--- a/test/run_and_collect_test.dart
+++ b/test/run_and_collect_test.dart
@@ -43,7 +43,22 @@ void main() {
     expect(hitMap, contains(_sampleAppFileUri));
 
     Map<int, int> isolateFile = hitMap[_isolateLibFileUri];
-    expect(
-        isolateFile, {9: 1, 10: 1, 12: 0, 19: 1, 21: 1, 23: 1, 24: 3, 25: 1});
+    expect(isolateFile, {
+      10: 1,
+      11: 1,
+      13: 0,
+      17: 1,
+      18: 2,
+      20: 0,
+      // TODO(cbracken) remove line 21 coverage expectation when fixed:
+      // https://github.com/dart-lang/coverage/issues/196
+      21: 0,
+      27: 1,
+      29: 1,
+      30: 2,
+      31: 1,
+      32: 3,
+      33: 1,
+    });
   });
 }

--- a/test/test_files/test_app_isolate.dart
+++ b/test/test_files/test_app_isolate.dart
@@ -2,10 +2,18 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+import 'dart:async';
 import 'dart:io';
 import 'dart:isolate';
 
 String fooSync(int x) {
+  if (x == 42) {
+    return '*' * x;
+  }
+  return new List.generate(x, (_) => 'xyzzy').join(' ');
+}
+
+Future<String> fooAsync(int x) async {
   if (x == 42) {
     return '*' * x;
   }
@@ -19,8 +27,9 @@ void isolateTask(List<dynamic> threeThings) {
   sleep(const Duration(milliseconds: 500));
 
   fooSync(42);
-
-  SendPort port = threeThings.first;
-  int sum = threeThings[1] + threeThings[2];
-  port.send(sum);
+  fooAsync(42).then((_) {
+    SendPort port = threeThings.first;
+    int sum = threeThings[1] + threeThings[2];
+    port.send(sum);
+  });
 }


### PR DESCRIPTION
Adds a test to verify expected coverage is generated for an asynchronous
function with two branches, only one of which is executed.

Line 21 is currently marked coverable and not hit due to a VM bug. Once
https://github.com/dart-lang/sdk/issues/31222 is fixed and the new VM
released to stable, we should remove the test expectation for that line
and close https://github.com/dart-lang/coverage/issues/196.