### PR TITLE
Mark function definition as coverable

### DIFF
--- a/test/collect_coverage_test.dart
+++ b/test/collect_coverage_test.dart
@@ -71,11 +71,18 @@ void main() {
       32: 3,
       33: 1,
     };
-    // Dart VMs prior to 2.0.0-dev.5.0 contain a bug that emits coverage on the
-    // closing brace of async function blocks.
-    // See: https://github.com/dart-lang/coverage/issues/196
     if (Platform.version.startsWith('1.')) {
+      // Dart VMs prior to 2.0.0-dev.5.0 contain a bug that emits coverage on the
+      // closing brace of async function blocks.
+      // See: https://github.com/dart-lang/coverage/issues/196
       expectedHits[21] = 0;
+    } else {
+      // Dart VMs version 2.0.0-dev.6.0 mark the opening brace of a function as
+      // coverable.
+      expectedHits[9] = 1;
+      expectedHits[16] = 1;
+      expectedHits[26] = 1;
+      expectedHits[30] = 3;
     }
     expect(isolateFile, expectedHits);
   });

--- a/test/run_and_collect_test.dart
+++ b/test/run_and_collect_test.dart
@@ -64,6 +64,13 @@ void main() {
     // See: https://github.com/dart-lang/coverage/issues/196
     if (Platform.version.startsWith('1.')) {
       expectedHits[21] = 0;
+    } else {
+      // Dart VMs version 2.0.0-dev.6.0 mark the opening brace of a function as
+      // coverable.
+      expectedHits[9] = 1;
+      expectedHits[16] = 1;
+      expectedHits[26] = 1;
+      expectedHits[30] = 3;
     }
     expect(isolateFile, expectedHits);
   });


### PR DESCRIPTION
In VM commit https://dart-review.googlesource.com/c/sdk/+/16684/2,
function definitions were marked as coverable to handle cases such as
the following:

  int get meaningOfLifeTheUniverseAndEverything => 42;