### PR TITLE
Fix warnings related to fuzzy arrows.

### DIFF
--- a/lib/src/collect.dart
+++ b/lib/src/collect.dart
@@ -80,9 +80,11 @@ Future _waitIsolatesPaused(VMServiceClient service, {Duration timeout}) async {
 Future<List<Map<String, dynamic>>> _getCoverageJson(
     VMServiceClient service, VMSourceReport report) async {
   var scriptRefs = report.ranges.map((r) => r.script).toSet();
-  var scripts = new Map<Uri, VMScript>.fromIterable(
-      await Future.wait<VMScript>(scriptRefs.map((ref) => ref.load()).toList()),
-      key: (VMScript s) => s.uri);
+  var scripts = <Uri, VMScript>{};
+  for (var script in await Future
+      .wait<VMScript>(scriptRefs.map((ref) => ref.load()).toList())) {
+    scripts[script.uri] = script;
+  }
 
   // script uri -> { line -> hit count }
   var hitMaps = <Uri, Map<int, int>>{};

--- a/lib/src/hitmap.dart
+++ b/lib/src/hitmap.dart
@@ -8,7 +8,7 @@ import 'dart:io';
 
 /// Creates a single hitmap from a raw json object. Throws away all entries that
 /// are not resolvable.
-Map createHitmap(List<Map> json) {
+Map<String, Map<int, int>> createHitmap(List<Map> json) {
   // Map of source file to map of line to hit count for that line.
   var globalHitMap = <String, Map<int, int>>{};
 
@@ -51,8 +51,9 @@ Map createHitmap(List<Map> json) {
 }
 
 /// Merges [newMap] into [result].
-void mergeHitmaps(Map newMap, Map result) {
-  newMap.forEach((String file, Map v) {
+void mergeHitmaps(
+    Map<String, Map<int, int>> newMap, Map<String, Map<int, int>> result) {
+  newMap.forEach((String file, Map<int, int> v) {
     if (result.containsKey(file)) {
       v.forEach((int line, int cnt) {
         if (result[file][line] == null) {
@@ -69,7 +70,7 @@ void mergeHitmaps(Map newMap, Map result) {
 
 /// Generates a merged hitmap from a set of coverage JSON files.
 Future<Map> parseCoverage(Iterable<File> files, int _) async {
-  Map globalHitmap = <String, Map<int, int>>{};
+  var globalHitmap = <String, Map<int, int>>{};
   for (var file in files) {
     String contents = file.readAsStringSync();
     List<Map<String, dynamic>> json = JSON.decode(contents)['coverage'];

--- a/lib/src/resolver.dart
+++ b/lib/src/resolver.dart
@@ -157,7 +157,7 @@ class Loader {
   final List<String> failed = [];
 
   /// Loads an imported resource and returns a [Future] with a [List] of lines.
-  /// Returns [null] if the resource could not be loaded.
+  /// Returns `null` if the resource could not be loaded.
   Future<List<String>> load(String path) async {
     try {
       return new File(path).readAsLines();

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: coverage
-version: 0.9.4-dev
+version: 0.10.0-dev
 author: Dart Team <misc@dartlang.org>
 description: Coverage data manipulation and formatting
 homepage: https://github.com/dart-lang/coverage

--- a/test/collect_coverage_api_test.dart
+++ b/test/collect_coverage_api_test.dart
@@ -26,7 +26,8 @@ void main() {
     List coverage = json['coverage'];
     expect(coverage, isNotEmpty);
 
-    var sources = coverage.fold(<String, dynamic>{}, (Map map, Map value) {
+    var sources = coverage.fold(<String, dynamic>{},
+        (Map<String, dynamic> map, dynamic value) {
       String sourceUri = value['source'];
       map.putIfAbsent(sourceUri, () => <Map>[]).add(value);
       return map;

--- a/test/lcov_test.dart
+++ b/test/lcov_test.dart
@@ -13,12 +13,9 @@ import 'package:test/test.dart';
 
 final _sampleAppPath = p.join('test', 'test_files', 'test_app.dart');
 final _isolateLibPath = p.join('test', 'test_files', 'test_app_isolate.dart');
-final _collectAppPath = p.join('bin', 'collect_coverage.dart');
 
 final _sampleAppFileUri = p.toUri(p.absolute(_sampleAppPath)).toString();
 final _isolateLibFileUri = p.toUri(p.absolute(_isolateLibPath)).toString();
-
-const _timeout = const Duration(seconds: 5);
 
 void main() {
   test('validate hitMap', () async {

--- a/test/test_files/test_app_isolate.dart
+++ b/test/test_files/test_app_isolate.dart
@@ -23,7 +23,7 @@ Future<String> fooAsync(int x) async {
 /// The number of covered lines is tested and expected to be 4.
 ///
 /// If you modify this method, you may have to update the tests!
-void isolateTask(List<dynamic> threeThings) {
+void isolateTask(dynamic threeThings) {
   sleep(const Duration(milliseconds: 500));
 
   fooSync(42);


### PR DESCRIPTION
These will become an arrow in Dart 2.0. See this bug for more context:

  https://github.com/dart-lang/sdk/issues/29630

I also fixed a couple of unused variable warnings while I was at it.

I bumped the version number in the pubspec. This is technically a
potentially breaking change because the signatures of createHitmap() and
mergeHitmaps() are more precise now. The only code I could find calling
that was in flutter_tools and that seems to be happy with the change.
If you'd rather I keep the old version, let me know.