### PR TITLE
Use the expanded test reporter

### DIFF
--- a/tool/travis.sh
+++ b/tool/travis.sh
@@ -26,7 +26,7 @@ fi
 
 # Run the tests.
 echo "Running tests..."
-pub run test
+pub run test --reporter expanded
 
 # Gather coverage and upload to Coveralls.
 if [ "$COVERALLS_TOKEN" ] && [ "$TRAVIS_DART_VERSION" = "stable" ]; then


### PR DESCRIPTION
This ensures we emit one line per test as opposed to overwriting results
in stdout with each pass.