### PR TITLE
Version 0.11.0: Migrate to Dart 2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: dart
 dart:
   - dev
-  - stable
 install:
   - gem install coveralls-lcov
 script: ./tool/travis.sh

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,9 @@
-## 0.10-0 - 2017-12-14
+## 0.11.0 - 2018-04-12
+
+ * BREAKING CHANGE: This version requires Dart SDK 2.0.0-dev.30 or later.
+ * Updated to Dart 2.0 constants from dart:convert.
+
+## 0.10.0 - 2017-12-14
 
  * BREAKING CHANGE: `createHitmap` and `mergeHitmaps` now specify generic types
    (`Map<String, Map<int, int>>`) on their hit map parameter/return value.

--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -8,8 +8,6 @@
 # https://github.com/dart-lang/sdk/tree/master/pkg/analyzer#configuring-the-analyzer
 
 analyzer:
-  language:
-    enableStrictCallChecks: true
   strong-mode:
     implicit-dynamic: false
   errors:

--- a/bin/collect_coverage.dart
+++ b/bin/collect_coverage.dart
@@ -3,7 +3,7 @@
 // BSD-style license that can be found in the LICENSE file.
 
 import 'dart:async';
-import 'dart:convert' show JSON;
+import 'dart:convert' show json;
 import 'dart:io';
 
 import 'package:args/args.dart';
@@ -22,7 +22,7 @@ Future<Null> main(List<String> arguments) async {
     var coverage = await collect(
         options.serviceUri, options.resume, options.waitPaused,
         timeout: options.timeout);
-    options.out.write(JSON.encode(coverage));
+    options.out.write(json.encode(coverage));
     await options.out.close();
   }, onError: (dynamic error, Chain chain) {
     stderr.writeln(error);

--- a/lib/src/hitmap.dart
+++ b/lib/src/hitmap.dart
@@ -3,12 +3,12 @@
 // BSD-style license that can be found in the LICENSE file.
 
 import 'dart:async';
-import 'dart:convert';
+import 'dart:convert' show json;
 import 'dart:io';
 
 /// Creates a single hitmap from a raw json object. Throws away all entries that
 /// are not resolvable.
-Map<String, Map<int, int>> createHitmap(List<Map> json) {
+Map<String, Map<int, int>> createHitmap(List<Map> jsonResult) {
   // Map of source file to map of line to hit count for that line.
   var globalHitMap = <String, Map<int, int>>{};
 
@@ -17,7 +17,7 @@ Map<String, Map<int, int>> createHitmap(List<Map> json) {
     map[line] = count + oldCount;
   }
 
-  for (Map<String, dynamic> e in json) {
+  for (Map<String, dynamic> e in jsonResult) {
     String source = e['source'];
     if (source == null) {
       // Couldn't resolve import, so skip this entry.
@@ -73,8 +73,8 @@ Future<Map> parseCoverage(Iterable<File> files, int _) async {
   var globalHitmap = <String, Map<int, int>>{};
   for (var file in files) {
     String contents = file.readAsStringSync();
-    List<Map<String, dynamic>> json = JSON.decode(contents)['coverage'];
-    mergeHitmaps(createHitmap(json), globalHitmap);
+    List<Map<String, dynamic>> jsonResult = json.decode(contents)['coverage'];
+    mergeHitmaps(createHitmap(jsonResult), globalHitmap);
   }
   return globalHitmap;
 }

--- a/lib/src/run_and_collect.dart
+++ b/lib/src/run_and_collect.dart
@@ -3,7 +3,7 @@
 // BSD-style license that can be found in the LICENSE file.
 
 import 'dart:async';
-import 'dart:convert' show UTF8, LineSplitter;
+import 'dart:convert' show utf8, LineSplitter;
 import 'dart:io';
 
 import 'collect.dart';
@@ -36,7 +36,7 @@ Future<Map<String, dynamic>> runAndCollect(String scriptPath,
   var process = await Process.start('dart', dartArgs);
   var serviceUriCompleter = new Completer<Uri>();
   process.stdout
-      .transform(UTF8.decoder)
+      .transform(utf8.decoder)
       .transform(const LineSplitter())
       .listen((line) {
     var uri = extractObservatoryUri(line);

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,10 +1,10 @@
 name: coverage
-version: 0.10.0
+version: 0.11.0
 author: Dart Team <misc@dartlang.org>
 description: Coverage data manipulation and formatting
 homepage: https://github.com/dart-lang/coverage
 environment:
-  sdk: '>=1.21.0 <2.0.0'
+  sdk: '>=2.0.0-dev.30 <2.0.0'
 dependencies:
   args: '>=1.0.0 <2.0.0'
   logging: '>=0.9.0 <0.12.0'

--- a/test/collect_coverage_api_test.dart
+++ b/test/collect_coverage_api_test.dart
@@ -61,7 +61,7 @@ Future<Map<String, dynamic>> _collectCoverage() async {
   // Capture the VM service URI.
   Completer<Uri> serviceUriCompleter = new Completer<Uri>();
   sampleProcess.stdout
-      .transform(UTF8.decoder)
+      .transform(utf8.decoder)
       .transform(new LineSplitter())
       .listen((line) {
     if (!serviceUriCompleter.isCompleted) {

--- a/test/collect_coverage_test.dart
+++ b/test/collect_coverage_test.dart
@@ -3,7 +3,7 @@
 // BSD-style license that can be found in the LICENSE file.
 
 import 'dart:async';
-import 'dart:convert';
+import 'dart:convert' show json, LineSplitter, utf8;
 import 'dart:io';
 
 import 'package:coverage/coverage.dart';
@@ -24,12 +24,12 @@ void main() {
     var resultString = await _getCoverageResult();
 
     // analyze the output json
-    Map<String, dynamic> json = JSON.decode(resultString);
+    Map<String, dynamic> jsonResult = json.decode(resultString);
 
-    expect(json.keys, unorderedEquals(<String>['type', 'coverage']));
-    expect(json, containsPair('type', 'CodeCoverage'));
+    expect(jsonResult.keys, unorderedEquals(<String>['type', 'coverage']));
+    expect(jsonResult, containsPair('type', 'CodeCoverage'));
 
-    List<Map<String, dynamic>> coverage = json['coverage'];
+    List<Map<String, dynamic>> coverage = jsonResult['coverage'];
     expect(coverage, isNotEmpty);
 
     var sources = coverage.fold(<String, dynamic>{}, (Map map, Map value) {
@@ -49,8 +49,8 @@ void main() {
 
   test('createHitmap', () async {
     var resultString = await _getCoverageResult();
-    Map<String, dynamic> json = JSON.decode(resultString);
-    List<Map<String, dynamic>> coverage = json['coverage'];
+    Map<String, dynamic> jsonResult = json.decode(resultString);
+    List<Map<String, dynamic>> coverage = jsonResult['coverage'];
     var hitMap = createHitmap(coverage);
     expect(hitMap, contains(_sampleAppFileUri));
 
@@ -124,7 +124,7 @@ Future<String> _collectCoverage() async {
   // Capture the VM service URI.
   Completer<Uri> serviceUriCompleter = new Completer<Uri>();
   sampleProcess.stdout
-      .transform(UTF8.decoder)
+      .transform(utf8.decoder)
       .transform(new LineSplitter())
       .listen((line) {
     if (!serviceUriCompleter.isCompleted) {

--- a/test/lcov_test.dart
+++ b/test/lcov_test.dart
@@ -162,7 +162,7 @@ Future<Map> _getHitMap() async {
   // Capture the VM service URI.
   Completer<Uri> serviceUriCompleter = new Completer<Uri>();
   sampleProcess.stdout
-      .transform(UTF8.decoder)
+      .transform(utf8.decoder)
       .transform(new LineSplitter())
       .listen((line) {
     if (!serviceUriCompleter.isCompleted) {

--- a/tool/travis.sh
+++ b/tool/travis.sh
@@ -29,7 +29,7 @@ echo "Running tests..."
 pub run test --reporter expanded
 
 # Gather coverage and upload to Coveralls.
-if [ "$COVERALLS_TOKEN" ] && [ "$TRAVIS_DART_VERSION" = "stable" ]; then
+if [ "$COVERALLS_TOKEN" ] && [ "$TRAVIS_DART_VERSION" = "dev" ]; then
   OBS_PORT=9292
   echo "Collecting coverage on port $OBS_PORT..."
 


### PR DESCRIPTION
This commit migrates package:coverage to Dart 2. If any further Dart 1
bugfixes are required, they will be made on a dart_1 branch and released
as 0.10.x patch releases.