### PR TITLE
Update tests for Dart SDK 2.0.0-dev.64.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Unreleased changes
+
+ * Strong mode fixes as of Dart SDK 2.0.0-dev.64.1.
+
 ## 0.11.0 - 2018-04-12
 
  * BREAKING CHANGE: This version requires Dart SDK 2.0.0-dev.30 or later.

--- a/lib/src/run_and_collect.dart
+++ b/lib/src/run_and_collect.dart
@@ -11,7 +11,7 @@ import 'util.dart';
 
 Future<Map<String, dynamic>> runAndCollect(String scriptPath,
     {List<String> scriptArgs,
-    bool checked: true,
+    bool checked: false,
     String packageRoot,
     Duration timeout}) async {
   var dartArgs = [

--- a/test/collect_coverage_test.dart
+++ b/test/collect_coverage_test.dart
@@ -29,10 +29,10 @@ void main() {
     expect(jsonResult.keys, unorderedEquals(<String>['type', 'coverage']));
     expect(jsonResult, containsPair('type', 'CodeCoverage'));
 
-    List<Map<String, dynamic>> coverage = jsonResult['coverage'];
+    List coverage = jsonResult['coverage'];
     expect(coverage, isNotEmpty);
 
-    var sources = coverage.fold(<String, dynamic>{}, (Map map, Map value) {
+    var sources = coverage.fold({}, (Map map, value) {
       String sourceUri = value['source'];
       map.putIfAbsent(sourceUri, () => <Map>[]).add(value);
       return map;
@@ -50,7 +50,7 @@ void main() {
   test('createHitmap', () async {
     var resultString = await _getCoverageResult();
     Map<String, dynamic> jsonResult = json.decode(resultString);
-    List<Map<String, dynamic>> coverage = jsonResult['coverage'];
+    List coverage = jsonResult['coverage'];
     var hitMap = createHitmap(coverage);
     expect(hitMap, contains(_sampleAppFileUri));
 

--- a/test/run_and_collect_test.dart
+++ b/test/run_and_collect_test.dart
@@ -25,7 +25,7 @@ void main() {
     List<Map> coverage = json['coverage'];
     expect(coverage, isNotEmpty);
 
-    var sources = coverage.fold(<String, dynamic>{}, (Map map, Map value) {
+    var sources = coverage.fold({}, (Map map, value) {
       String sourceUri = value['source'];
       map.putIfAbsent(sourceUri, () => <Map>[]).add(value);
       return map;
@@ -48,7 +48,7 @@ void main() {
       11: 1,
       13: 0,
       17: 1,
-      18: 2,
+      18: 1,
       20: 0,
       27: 1,
       29: 1,

--- a/test/test_util.dart
+++ b/test/test_util.dart
@@ -9,7 +9,7 @@ import 'package:path/path.dart' as p;
 
 final String testAppPath = p.join('test', 'test_files', 'test_app.dart');
 
-const Duration timeout = const Duration(seconds: 10);
+const Duration timeout = const Duration(seconds: 20);
 
 Future<Process> runTestApp(int openPort) async {
   return Process.start('dart', [


### PR DESCRIPTION
The --checked flag has been removed in Dart SDK 2.0.0-dev.64.1. This
changes the default for the `checked` parameter in runAndCollect() to
false. In Dart 2, checked mode is no longer necessary, since type checks
are done statically at compile time. Support for the --checked flag will
be removed in a future version of package:coverage.