### PR TITLE
Minor type, formatting fixes for 2.0.0-dev.64.1

### DIFF
--- a/bin/format_coverage.dart
+++ b/bin/format_coverage.dart
@@ -99,8 +99,7 @@ Environment parseArgs(List<String> arguments) {
   parser.addOption('in', abbr: 'i', help: 'input(s): may be file or directory');
   parser.addOption('out',
       abbr: 'o', defaultsTo: 'stdout', help: 'output: may be file or stdout');
-  parser.addOption('report-on',
-      allowMultiple: true,
+  parser.addMultiOption('report-on',
       help: 'which directories or files to report coverage on');
   parser.addOption('workers',
       abbr: 'j', defaultsTo: '1', help: 'number of workers');

--- a/lib/src/collect.dart
+++ b/lib/src/collect.dart
@@ -81,8 +81,8 @@ Future<List<Map<String, dynamic>>> _getCoverageJson(
     VMServiceClient service, VMSourceReport report) async {
   var scriptRefs = report.ranges.map((r) => r.script).toSet();
   var scripts = <Uri, VMScript>{};
-  for (var script in await Future
-      .wait<VMScript>(scriptRefs.map((ref) => ref.load()).toList())) {
+  for (var script in await Future.wait<VMScript>(
+      scriptRefs.map((ref) => ref.load()).toList())) {
     scripts[script.uri] = script;
   }
 

--- a/lib/src/resolver.dart
+++ b/lib/src/resolver.dart
@@ -80,7 +80,7 @@ class Resolver {
   String resolveSymbolicLinks(String path) {
     var normalizedPath = p.normalize(path);
     var type = FileSystemEntity.typeSync(normalizedPath, followLinks: true);
-    if (type == FileSystemEntityType.NOT_FOUND) return null;
+    if (type == FileSystemEntityType.notFound) return null;
     return new File(normalizedPath).resolveSymbolicLinksSync();
   }
 

--- a/lib/src/util.dart
+++ b/lib/src/util.dart
@@ -59,11 +59,11 @@ Future<int> getOpenPort() async {
   ServerSocket socket;
 
   try {
-    socket = await ServerSocket.bind(InternetAddress.LOOPBACK_IP_V4, 0);
+    socket = await ServerSocket.bind(InternetAddress.loopbackIPv4, 0);
   } catch (_) {
     // try again v/ V6 only. Slight possibility that V4 is disabled
-    socket = await ServerSocket.bind(InternetAddress.LOOPBACK_IP_V6, 0,
-        v6Only: true);
+    socket =
+        await ServerSocket.bind(InternetAddress.loopbackIPv6, 0, v6Only: true);
   }
 
   try {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,12 +1,12 @@
 name: coverage
-version: 0.12.0
+version: 0.12.1
 author: Dart Team <misc@dartlang.org>
 description: Coverage data manipulation and formatting
 homepage: https://github.com/dart-lang/coverage
 environment:
   sdk: '>=2.0.0-dev.64.1 <2.0.0'
 dependencies:
-  args: '>=1.0.0 <2.0.0'
+  args: '>=1.4.0 <2.0.0'
   logging: '>=0.9.0 <0.12.0'
   package_config: ">=0.1.5 <2.0.0"
   path: '>=0.9.0 <2.0.0'

--- a/test/collect_coverage_test.dart
+++ b/test/collect_coverage_test.dart
@@ -32,7 +32,8 @@ void main() {
     List coverage = jsonResult['coverage'];
     expect(coverage, isNotEmpty);
 
-    var sources = coverage.fold({}, (Map map, value) {
+    var sources = coverage.fold<Map<String, dynamic>>(<String, dynamic>{},
+        (Map<String, dynamic> map, dynamic value) {
       String sourceUri = value['source'];
       map.putIfAbsent(sourceUri, () => <Map>[]).add(value);
       return map;

--- a/test/run_and_collect_test.dart
+++ b/test/run_and_collect_test.dart
@@ -25,7 +25,8 @@ void main() {
     List<Map> coverage = json['coverage'];
     expect(coverage, isNotEmpty);
 
-    var sources = coverage.fold({}, (Map map, value) {
+    var sources = coverage.fold<Map<String, dynamic>>(<String, dynamic>{},
+        (Map<String, dynamic> map, dynamic value) {
       String sourceUri = value['source'];
       map.putIfAbsent(sourceUri, () => <Map>[]).add(value);
       return map;


### PR DESCRIPTION
* Eliminate use of deprecated Dart 1 constants. 
* Update to more recent package:args.
* Update to dartfmt from 2.0.0-dev.65.0.