### PR TITLE
Version 0.12.1 (#224)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.12.1 - 2018-06-26
+
+ * Minor type, dartfmt fixes.
+ * Require package:args >= 1.4.0.
+
 ## 0.12.0 - 2018-06-26
 
  * BREAKING CHANGE: This version requires Dart SDK 2.0.0-dev.64.1 or later.


### PR DESCRIPTION
* Eliminate use of deprecated Dart 1 constants.
* Update to more recent package:args.
* Update to dartfmt from 2.0.0-dev.65.0.