### PR TITLE
Fixed version conflict with dart 2.1.0/flutter 0.6

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -4,7 +4,7 @@ author: Dart Team <misc@dartlang.org>
 description: Coverage data manipulation and formatting
 homepage: https://github.com/dart-lang/coverage
 environment:
-  sdk: '>=2.0.0-dev.68.0 <3.0.0'
+  sdk: '>=2.0.0-dev.58.0 <3.0.0'
 dependencies:
   args: '>=1.4.0 <2.0.0'
   logging: '>=0.9.0 <0.12.0'

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -4,7 +4,7 @@ author: Dart Team <misc@dartlang.org>
 description: Coverage data manipulation and formatting
 homepage: https://github.com/dart-lang/coverage
 environment:
-  sdk: '>=2.0.0-dev.64.1 <3.0.0'
+  sdk: '>=2.0.0-dev.68.0 <3.0.0'
 dependencies:
   args: '>=1.4.0 <2.0.0'
   logging: '>=0.9.0 <0.12.0'


### PR DESCRIPTION
Check https://github.com/flutter/flutter/issues/20700 for more info.

Issue is resolved by just setting a minimum environment version for the
plugin.