### PR TITLE
Replace uses of forEach with for-in loops

### DIFF
--- a/bin/format_coverage.dart
+++ b/bin/format_coverage.dart
@@ -77,11 +77,15 @@ Future<Null> main(List<String> arguments) async {
   if (env.verbose) {
     if (resolver.failed.length > 0) {
       print('Failed to resolve:');
-      resolver.failed.toSet().forEach((e) => print('  $e'));
+      for (String error in resolver.failed.toSet()) {
+        print('  $error');
+      }
     }
     if (loader.failed.length > 0) {
       print('Failed to load:');
-      loader.failed.toSet().forEach((e) => print('  $e'));
+      for (String error in loader.failed.toSet()) {
+        print('  $error');
+      }
     }
   }
   await env.output.close();

--- a/lib/src/formatter.dart
+++ b/lib/src/formatter.dart
@@ -51,9 +51,9 @@ class LcovFormatter implements Formatter {
 
       buf.write('SF:$source\n');
       final lines = v.keys.toList()..sort();
-      lines.forEach((int k) {
+      for (int k in lines) {
         buf.write('DA:$k,${v[k]}\n');
-      });
+      }
       buf.write('LF:${lines.length}\n');
       buf.write('LH:${lines.where((k) => v[k] > 0).length}\n');
       buf.write('end_of_record\n');


### PR DESCRIPTION
Generally, for-loops should be preferred over forEach() unless calling
an existing unary function.

See: https://www.dartlang.org/guides/language/effective-dart/usage#avoid-using-iterableforeach-with-a-function-literal

This is a minor usage cleanup; no changes to functionality.