### PR TITLE
Run Travis CI tests on Dart stable branch

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: dart
 dart:
-  - dev
+  - stable
 install:
   - gem install coveralls-lcov
 script: ./tool/travis.sh


### PR DESCRIPTION
Tests were switched to dev branch prior to Dart 2.0 going stable in
order to ensure compatibility with Dart 2. Now that Dart 2 has gone
stable, migrate back to stable branch to avoid failures due to VM/SDK
bugs.