### PR TITLE
Move constructor definitions to top of classes

### DIFF
--- a/bin/collect_coverage.dart
+++ b/bin/collect_coverage.dart
@@ -34,13 +34,14 @@ Future<Null> main(List<String> arguments) async {
 }
 
 class Options {
+  Options(
+      this.serviceUri, this.out, this.timeout, this.waitPaused, this.resume);
+
   final Uri serviceUri;
   final IOSink out;
   final Duration timeout;
   final bool waitPaused;
   final bool resume;
-  Options(
-      this.serviceUri, this.out, this.timeout, this.waitPaused, this.resume);
 }
 
 Options _parseArgs(List<String> arguments) {

--- a/lib/src/formatter.dart
+++ b/lib/src/formatter.dart
@@ -19,16 +19,16 @@ abstract class Formatter {
 /// Returns a [Future] that completes as soon as all map entries have been
 /// emitted.
 class LcovFormatter implements Formatter {
-  final Resolver resolver;
-  final String basePath;
-  final List<String> reportOn;
-
   /// Creates a new LCOV formatter.
   ///
   /// If [reportOn] is provided, coverage report output is limited to files
   /// prefixed with one of the paths included. If [basePath] is provided, paths
   /// are reported relative to that path.
   LcovFormatter(this.resolver, {this.reportOn, this.basePath});
+
+  final Resolver resolver;
+  final String basePath;
+  final List<String> reportOn;
 
   @override
   Future<String> format(Map hitmap) async {
@@ -69,15 +69,15 @@ class LcovFormatter implements Formatter {
 /// Returns a [Future] that completes as soon as all map entries have been
 /// emitted.
 class PrettyPrintFormatter implements Formatter {
-  final Resolver resolver;
-  final Loader loader;
-  final List<String> reportOn;
-
   /// Creates a new pretty-print formatter.
   ///
   /// If [reportOn] is provided, coverage report output is limited to files
   /// prefixed with one of the paths included.
   PrettyPrintFormatter(this.resolver, this.loader, {this.reportOn});
+
+  final Resolver resolver;
+  final Loader loader;
+  final List<String> reportOn;
 
   @override
   Future<String> format(Map hitmap) async {

--- a/lib/src/resolver.dart
+++ b/lib/src/resolver.dart
@@ -10,15 +10,15 @@ import 'package:path/path.dart' as p;
 
 /// [Resolver] resolves imports with respect to a given environment.
 class Resolver {
+  Resolver({String packagesPath, this.packageRoot, this.sdkRoot})
+      : packagesPath = packagesPath,
+        _packages = packagesPath != null ? _parsePackages(packagesPath) : null;
+
   final String packagesPath;
   final String packageRoot;
   final String sdkRoot;
   final List<String> failed = [];
   Map<String, Uri> _packages;
-
-  Resolver({String packagesPath, this.packageRoot, this.sdkRoot})
-      : packagesPath = packagesPath,
-        _packages = packagesPath != null ? _parsePackages(packagesPath) : null;
 
   /// Returns the absolute path wrt. to the given environment or null, if the
   /// import could not be resolved.
@@ -92,10 +92,10 @@ class Resolver {
 
 /// Bazel URI resolver.
 class BazelResolver extends Resolver {
-  final String workspacePath;
-
   /// Creates a Bazel resolver with the specified workspace path, if any.
   BazelResolver({this.workspacePath: ''});
+
+  final String workspacePath;
 
   /// Returns the absolute path wrt. to the given environment or null, if the
   /// import could not be resolved.


### PR DESCRIPTION
Fixes lint: sort_constructors_first (Sort constructor declarations
before other members).