### PR TITLE
Fix format_coverage type error

### DIFF
--- a/bin/format_coverage.dart
+++ b/bin/format_coverage.dart
@@ -224,7 +224,8 @@ List<File> filesToProcess(String absPath) {
   if (FileSystemEntity.isDirectorySync(absPath)) {
     return new Directory(absPath)
         .listSync(recursive: true)
-        .where((e) => e is File && filePattern.hasMatch(p.basename(e.path)))
+        .whereType<File>()
+        .where((e) => filePattern.hasMatch(p.basename(e.path)))
         .toList();
   }
   return <File>[new File(absPath)];


### PR DESCRIPTION
Fixes #239.   Corrects a runtime type error when reading a directory of files.