### PR TITLE
Throw ArgumentError when null serviceUri specified

### DIFF
--- a/lib/src/collect.dart
+++ b/lib/src/collect.dart
@@ -12,6 +12,8 @@ const _retryInterval = const Duration(milliseconds: 200);
 Future<Map<String, dynamic>> collect(
     Uri serviceUri, bool resume, bool waitPaused,
     {Duration timeout}) async {
+  if (serviceUri == null) throw ArgumentError('serviceUri must not be null');
+
   // Create websocket URI. Handle any trailing slashes.
   var pathSegments = serviceUri.pathSegments.where((c) => c.isNotEmpty).toList()
     ..add('ws');

--- a/lib/src/collect.dart
+++ b/lib/src/collect.dart
@@ -9,6 +9,20 @@ import 'util.dart';
 
 const _retryInterval = const Duration(milliseconds: 200);
 
+/// Collects coverage for all isolates in the running VM.
+///
+/// Collects a hit-map containing merged coverage for all isolates in the Dart
+/// VM associated with the specified [serviceUri]. Returns a map suitable for
+/// input to the coverage formatters that ship with this package.
+///
+/// [serviceUri] must specify the http/https URI of the service port of a
+/// running Dart VM and must not be null.
+///
+/// If [resume] is true, all isolates will be resumed once coverage collection
+/// is complate.
+///
+/// If [waitPaused] is true, collection will not begin until all isolates are
+/// in the paused state.
 Future<Map<String, dynamic>> collect(
     Uri serviceUri, bool resume, bool waitPaused,
     {Duration timeout}) async {

--- a/test/collect_coverage_api_test.dart
+++ b/test/collect_coverage_api_test.dart
@@ -18,6 +18,10 @@ final _sampleAppFileUri = p.toUri(p.absolute(testAppPath)).toString();
 final _isolateLibFileUri = p.toUri(p.absolute(_isolateLibPath)).toString();
 
 void main() {
+  test('collect throws when serviceUri is null', () {
+    expect(() => collect(null, true, false), throwsArgumentError);
+  });
+
   test('collect_coverage_api', () async {
     Map<String, dynamic> json = await _getCoverageResult();
     expect(json.keys, unorderedEquals(<String>['type', 'coverage']));


### PR DESCRIPTION
If a null serviceUri is passed to the collect() function, throw
ArgumentError. Flutter's coverage collection infra previously had a bug
wherein a null observatory port URL was sometimes passed to this
function. This makes debugging such cases marginally easier.

Fixes #227.