### PR TITLE
Wait for all isolates to pause in test runs

### DIFF
--- a/test/collect_coverage_api_test.dart
+++ b/test/collect_coverage_api_test.dart
@@ -77,5 +77,5 @@ Future<Map<String, dynamic>> _collectCoverage() async {
   });
   Uri serviceUri = await serviceUriCompleter.future;
 
-  return collect(serviceUri, true, false, timeout: timeout);
+  return collect(serviceUri, true, true, timeout: timeout);
 }


### PR DESCRIPTION
In order to ensure reproducible tests in collect_coverage_api_test.dart,
we need to ensure the test app on which we collect coverage has run to
completion before starting collection.

This patch changes the test coverage collection run to wait until all
isolates have run to completion and are in paused state before we begin
coverage collection.

The test app runs in a VM with the `--pause-isolates-on-exit` flag set,
which guarantees we don't clean up isolates that have exited, which
leaves the VM wedged until after we collect coverage and the collector
resumes all isolates (causing the test app to exit).