### PR TITLE
[WIP] Add comment detection to exclude lines from coverage

### DIFF
--- a/bin/format_coverage.dart
+++ b/bin/format_coverage.dart
@@ -44,7 +44,8 @@ Future<Null> main(List<String> arguments) async {
   }
 
   var clock = new Stopwatch()..start();
-  var hitmap = await parseCoverage(files, env.workers, checkIgnoredLines: env.checkIgnore);
+  var hitmap = await parseCoverage(files, env.workers,
+      checkIgnoredLines: env.checkIgnore);
 
   // All workers are done. Process the data.
   if (env.verbose) {
@@ -124,10 +125,11 @@ Environment parseArgs(List<String> arguments) {
       abbr: 'l',
       negatable: false,
       help: 'convert coverage data to lcov format');
-  parser.addFlag('check-ignore',
-      abbr: 'c',
-      negatable: false,
-      help: 'check for coverage ignore comments',
+  parser.addFlag(
+    'check-ignore',
+    abbr: 'c',
+    negatable: false,
+    help: 'check for coverage ignore comments',
   );
   parser.addFlag('verbose',
       abbr: 'v', negatable: false, help: 'verbose output');

--- a/bin/format_coverage.dart
+++ b/bin/format_coverage.dart
@@ -25,6 +25,7 @@ class Environment {
   bool lcov;
   bool expectMarkers;
   bool verbose;
+  bool checkIgnore;
 }
 
 Future<Null> main(List<String> arguments) async {
@@ -39,10 +40,11 @@ Future<Null> main(List<String> arguments) async {
     print('  package-root: ${env.pkgRoot}');
     print('  package-spec: ${env.packagesPath}');
     print('  report-on: ${env.reportOn}');
+    print('  check-ignore: ${env.checkIgnore}');
   }
 
   var clock = new Stopwatch()..start();
-  var hitmap = await parseCoverage(files, env.workers);
+  var hitmap = await parseCoverage(files, env.workers, checkIgnoredLines: env.checkIgnore);
 
   // All workers are done. Process the data.
   if (env.verbose) {
@@ -122,6 +124,11 @@ Environment parseArgs(List<String> arguments) {
       abbr: 'l',
       negatable: false,
       help: 'convert coverage data to lcov format');
+  parser.addFlag('check-ignore',
+      abbr: 'c',
+      negatable: false,
+      help: 'check for coverage ignore comments',
+  );
   parser.addFlag('verbose',
       abbr: 'v', negatable: false, help: 'verbose output');
   parser.addFlag('help', abbr: 'h', negatable: false, help: 'show this help');
@@ -205,6 +212,8 @@ Environment parseArgs(List<String> arguments) {
   }
   // Use pretty-print either explicitly or by default.
   env.prettyPrint = !env.lcov;
+
+  env.checkIgnore = args['check-ignore'];
 
   try {
     env.workers = int.parse('${args["workers"]}');

--- a/lib/src/hitmap.dart
+++ b/lib/src/hitmap.dart
@@ -8,7 +8,8 @@ import 'dart:io';
 
 import 'resolver.dart';
 
-Future<List<int>> _getIgnoredLines(String source, Resolver resolver, Loader loader) async {
+Future<List<int>> _getIgnoredLines(
+    String source, Resolver resolver, Loader loader) async {
   final ignoredLines = new List<int>();
 
   final lines = await loader.load(resolver.resolve(source));
@@ -38,7 +39,8 @@ Future<List<int>> _getIgnoredLines(String source, Resolver resolver, Loader load
 /// are not resolvable.
 ///
 /// `jsonResult` is expected to be a List<Map<String, dynamic>>.
-Future<Map<String, Map<int, int>>> createHitmap(List jsonResult, { bool checkIgnoredLines: false }) async {
+Future<Map<String, Map<int, int>>> createHitmap(List jsonResult,
+    {bool checkIgnoredLines: false}) async {
   // Map of source file to map of line to hit count for that line.
   var globalHitMap = <String, Map<int, int>>{};
   final resolver = new Resolver();
@@ -56,7 +58,9 @@ Future<Map<String, Map<int, int>>> createHitmap(List jsonResult, { bool checkIgn
       continue;
     }
 
-    final ignoredLines = checkIgnoredLines ? await _getIgnoredLines(source, resolver, loader) : new List<int>();
+    final ignoredLines = checkIgnoredLines
+        ? await _getIgnoredLines(source, resolver, loader)
+        : new List<int>();
 
     var sourceHitMap = globalHitMap.putIfAbsent(source, () => <int, int>{});
     List<dynamic> hits = e['hits'];
@@ -107,14 +111,17 @@ void mergeHitmaps(
 }
 
 /// Generates a merged hitmap from a set of coverage JSON files.
-Future<Map> parseCoverage(Iterable<File> files, int _, {
+Future<Map> parseCoverage(
+  Iterable<File> files,
+  int _, {
   bool checkIgnoredLines: false,
 }) async {
   var globalHitmap = <String, Map<int, int>>{};
   for (var file in files) {
     String contents = file.readAsStringSync();
     List jsonResult = json.decode(contents)['coverage'];
-    Map<String, Map<int, int>> hitmap = await createHitmap(jsonResult, checkIgnoredLines: checkIgnoredLines);
+    Map<String, Map<int, int>> hitmap =
+        await createHitmap(jsonResult, checkIgnoredLines: checkIgnoredLines);
     mergeHitmaps(hitmap, globalHitmap);
   }
   return globalHitmap;

--- a/test/collect_coverage_test.dart
+++ b/test/collect_coverage_test.dart
@@ -63,12 +63,55 @@ void main() {
       17: 1,
       18: 1,
       20: 0,
-      27: 1,
-      29: 1,
-      30: 2,
-      31: 1,
-      32: 3,
+      24: 0,
+      25: 0,
+      32: 1,
       33: 1,
+      35: 1,
+      36: 2,
+      37: 1,
+      38: 3,
+      39: 1,
+      42: 1,
+    };
+    if (Platform.version.startsWith('1.')) {
+      // Dart VMs prior to 2.0.0-dev.5.0 contain a bug that emits coverage on the
+      // closing brace of async function blocks.
+      // See: https://github.com/dart-lang/coverage/issues/196
+      expectedHits[21] = 0; // coverage:ignore-line
+    } else {
+      // Dart VMs version 2.0.0-dev.6.0 mark the opening brace of a function as
+      // coverable.
+      expectedHits[9] = 1;
+      expectedHits[16] = 1;
+      expectedHits[32] = 1;
+      expectedHits[36] = 3;
+    }
+    expect(isolateFile, expectedHits);
+  });
+
+  test('createHitmap with ignored lines', () async {
+    var resultString = await _getCoverageResult();
+    Map<String, dynamic> jsonResult = json.decode(resultString);
+    List coverage = jsonResult['coverage'];
+    var hitMap = await createHitmap(coverage, checkIgnoredLines: true);
+    expect(hitMap, contains(_sampleAppFileUri));
+
+    Map<int, int> isolateFile = hitMap[_isolateLibFileUri];
+    Map<int, int> expectedHits = {
+      10: 1,
+      11: 1,
+      13: 0,
+      17: 1,
+      18: 1,
+      20: 0,
+      32: 1,
+      33: 1,
+      35: 1,
+      36: 2,
+      37: 1,
+      38: 3,
+      39: 1,
     };
     if (Platform.version.startsWith('1.')) {
       // Dart VMs prior to 2.0.0-dev.5.0 contain a bug that emits coverage on the
@@ -80,8 +123,8 @@ void main() {
       // coverable.
       expectedHits[9] = 1;
       expectedHits[16] = 1;
-      expectedHits[26] = 1;
-      expectedHits[30] = 3;
+      expectedHits[32] = 1;
+      expectedHits[36] = 3;
     }
     expect(isolateFile, expectedHits);
   });

--- a/test/collect_coverage_test.dart
+++ b/test/collect_coverage_test.dart
@@ -52,7 +52,7 @@ void main() {
     var resultString = await _getCoverageResult();
     Map<String, dynamic> jsonResult = json.decode(resultString);
     List coverage = jsonResult['coverage'];
-    var hitMap = createHitmap(coverage);
+    var hitMap = await createHitmap(coverage);
     expect(hitMap, contains(_sampleAppFileUri));
 
     Map<int, int> isolateFile = hitMap[_isolateLibFileUri];

--- a/test/run_and_collect_test.dart
+++ b/test/run_and_collect_test.dart
@@ -40,7 +40,7 @@ void main() {
       expect(sampleCoverageData['hits'], isNotEmpty);
     }
 
-    var hitMap = createHitmap(coverage);
+    var hitMap = await createHitmap(coverage);
     expect(hitMap, contains(_sampleAppFileUri));
 
     Map<int, int> isolateFile = hitMap[_isolateLibFileUri];

--- a/test/run_and_collect_test.dart
+++ b/test/run_and_collect_test.dart
@@ -51,12 +51,15 @@ void main() {
       17: 1,
       18: 1,
       20: 0,
-      27: 1,
-      29: 1,
-      30: 2,
-      31: 1,
-      32: 3,
+      24: 0,
+      25: 0,
       33: 1,
+      35: 1,
+      36: 2,
+      37: 1,
+      38: 3,
+      39: 1,
+      42: 1,
     };
     // Dart VMs prior to 2.0.0-dev.5.0 contain a bug that emits coverage on the
     // closing brace of async function blocks.
@@ -68,8 +71,8 @@ void main() {
       // coverable.
       expectedHits[9] = 1;
       expectedHits[16] = 1;
-      expectedHits[26] = 1;
-      expectedHits[30] = 3;
+      expectedHits[32] = 1;
+      expectedHits[36] = 3;
     }
     expect(isolateFile, expectedHits);
   });

--- a/test/test_files/test_app_isolate.dart
+++ b/test/test_files/test_app_isolate.dart
@@ -32,4 +32,12 @@ void isolateTask(dynamic threeThings) {
     int sum = threeThings[1] + threeThings[2];
     port.send(sum);
   });
+
+  print("Ignored line."); // coverage:ignore-line
 }
+
+// coverage:ignore-start
+int fooUnusedIgnoredSync(int a, int b) {
+  return a + b;
+}
+// coverage:ignore-enc

--- a/test/test_files/test_app_isolate.dart
+++ b/test/test_files/test_app_isolate.dart
@@ -20,6 +20,12 @@ Future<String> fooAsync(int x) async {
   return new List.generate(x, (_) => 'xyzzy').join(' ');
 }
 
+// coverage:ignore-start
+int fooUnusedIgnoredSync(int a, int b) {
+  return a + b;
+}
+// coverage:ignore-end
+
 /// The number of covered lines is tested and expected to be 4.
 ///
 /// If you modify this method, you may have to update the tests!
@@ -35,9 +41,3 @@ void isolateTask(dynamic threeThings) {
 
   print("Ignored line."); // coverage:ignore-line
 }
-
-// coverage:ignore-start
-int fooUnusedIgnoredSync(int a, int b) {
-  return a + b;
-}
-// coverage:ignore-enc

--- a/test/test_files/test_app_isolate.dart
+++ b/test/test_files/test_app_isolate.dart
@@ -21,8 +21,8 @@ Future<String> fooAsync(int x) async {
 }
 
 // coverage:ignore-start
-int fooUnusedIgnoredSync(int a, int b) {
-  return a + b;
+int fooUnusedIgnoredSync(int a, int b, int c) {
+  return a + b + c;
 }
 // coverage:ignore-end
 


### PR DESCRIPTION
/cc @cbracken @eseidelGoogle 

(https://github.com/dart-lang/coverage/issues/162) I've implemented a basic solution to exclude code lines from coverage reports.  It works by looking in the source code for the following comments.

* `// coverage:ignore-line`
* `// coverage:ignore-start`
* `// coverage:ignore-end`

It builds a list of line numbers which are then excluded from the hitmap. Ignoring code is enabled when using the `--check-ignore` or `-c` flag. I'm looking forward to your feedback!

### Results (generated using genhtml with the coverage.lcov file)
Without ignore comments:
![code coverage without ignore](https://user-images.githubusercontent.com/495620/51612606-16993800-1f22-11e9-95b0-a47b8e0894a9.png)

With ignore comments (line numbers changed because I added a test)
![code coverage with ignore](https://user-images.githubusercontent.com/495620/51612615-1c8f1900-1f22-11e9-8353-9b281e7188e7.png)

### TODO:
- [ ] Possibly implement `// coverage:ignore-file`
- [ ] Measure performance impact.
- [ ] Maybe check for `//coverage:ignore-line` aswell (without whitespace)
- [ ] Revisit naming of `--check-ignore` command
- [ ] Test with Dart VMs prior to 2.0.0-dev.5.0