### PR TITLE
Collect coverage data on isolate exit

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,8 @@ collected, it will wait until it detects a VM observatory to which it can
 connect. An optional `--connect-timeout` may be specified (in seconds).  The
 `--wait-paused` flag may be enabled, causing `collect_coverage` to wait until
 all isolates are paused before collecting coverage.
+Instead of waiting for all isolates to be paused, the `--on-exit` flag can be
+used to collect coverage whenever any isolate exits.
 
 #### Formatting coverage data
 
@@ -50,7 +52,7 @@ all isolates are paused before collecting coverage.
 pub global run coverage:format_coverage --packages=app_package/.packages -i coverage.json
 ```
 
-or if the `pub global run` exectuables are on your PATH,
+or if the `pub global run` executables are on your PATH,
 
 ```
 format_coverage --packages=app_package/.packages -i coverage.json

--- a/bin/collect_coverage.dart
+++ b/bin/collect_coverage.dart
@@ -34,8 +34,8 @@ Future<Null> main(List<String> arguments) async {
 }
 
 class Options {
-  Options(
-      this.serviceUri, this.out, this.timeout, this.waitPaused, this.onExit, this.resume);
+  Options(this.serviceUri, this.out, this.timeout, this.waitPaused, this.onExit,
+      this.resume);
 
   final Uri serviceUri;
   final IOSink out;
@@ -113,6 +113,6 @@ Options _parseArgs(List<String> arguments) {
   var timeout = (args['connect-timeout'] == null)
       ? null
       : new Duration(seconds: int.parse(args['connect-timeout']));
-  return new Options(
-      serviceUri, out, timeout, args['wait-paused'], args['on-exit'], args['resume-isolates']);
+  return new Options(serviceUri, out, timeout, args['wait-paused'],
+      args['on-exit'], args['resume-isolates']);
 }

--- a/bin/collect_coverage.dart
+++ b/bin/collect_coverage.dart
@@ -20,7 +20,7 @@ Future<Null> main(List<String> arguments) async {
   var options = _parseArgs(arguments);
   await Chain.capture(() async {
     var coverage = await collect(
-        options.serviceUri, options.resume, options.waitPaused,
+        options.serviceUri, options.resume, options.waitPaused, options.onExit,
         timeout: options.timeout);
     options.out.write(json.encode(coverage));
     await options.out.close();
@@ -35,12 +35,13 @@ Future<Null> main(List<String> arguments) async {
 
 class Options {
   Options(
-      this.serviceUri, this.out, this.timeout, this.waitPaused, this.resume);
+      this.serviceUri, this.out, this.timeout, this.waitPaused, this.onExit, this.resume);
 
   final Uri serviceUri;
   final IOSink out;
   final Duration timeout;
   final bool waitPaused;
+  final bool onExit;
   final bool resume;
 }
 
@@ -65,6 +66,10 @@ Options _parseArgs(List<String> arguments) {
         help: 'wait for all isolates to be paused before collecting coverage')
     ..addFlag('resume-isolates',
         abbr: 'r', defaultsTo: false, help: 'resume all isolates on exit')
+    ..addFlag('on-exit',
+        abbr: 'e',
+        defaultsTo: false,
+        help: 'collect coverage whenever an isolate exits')
     ..addFlag('help', abbr: 'h', negatable: false, help: 'show this help');
 
   var args = parser.parse(arguments);
@@ -109,5 +114,5 @@ Options _parseArgs(List<String> arguments) {
       ? null
       : new Duration(seconds: int.parse(args['connect-timeout']));
   return new Options(
-      serviceUri, out, timeout, args['wait-paused'], args['resume-isolates']);
+      serviceUri, out, timeout, args['wait-paused'], args['on-exit'], args['resume-isolates']);
 }

--- a/bin/collect_coverage.dart
+++ b/bin/collect_coverage.dart
@@ -23,6 +23,7 @@ Future<Null> main(List<String> arguments) async {
         options.serviceUri, options.resume, options.waitPaused, options.onExit,
         timeout: options.timeout);
     options.out.write(json.encode(coverage));
+    await options.out.flush();
     await options.out.close();
   }, onError: (dynamic error, Chain chain) {
     stderr.writeln(error);

--- a/bin/collect_coverage.dart
+++ b/bin/collect_coverage.dart
@@ -114,6 +114,6 @@ Options _parseArgs(List<String> arguments) {
   final timeout = (args['connect-timeout'] == null)
       ? null
       : Duration(seconds: int.parse(args['connect-timeout']));
-  return Options(serviceUri, out, timeout, args['wait-paused'],
-      args['on-exit'], args['resume-isolates']);
+  return Options(serviceUri, out, timeout, args['wait-paused'], args['on-exit'],
+      args['resume-isolates']);
 }

--- a/bin/collect_coverage.dart
+++ b/bin/collect_coverage.dart
@@ -19,8 +19,11 @@ Future<Null> main(List<String> arguments) async {
 
   final options = _parseArgs(arguments);
   await Chain.capture(() async {
-    final coverage = await collect(options.serviceUri, options.resume,
-        options.waitPaused, options.onExit, options.includeDart,
+    final coverage = await collect(options.serviceUri,
+        resume: options.resume,
+        waitPaused: options.waitPaused,
+        onExit: options.onExit,
+        includeDart: options.includeDart,
         timeout: options.timeout);
     options.out.write(json.encode(coverage));
     await options.out.flush();

--- a/lib/src/collect.dart
+++ b/lib/src/collect.dart
@@ -111,9 +111,9 @@ class _OneTimeCollector extends _CoverageCollector {
   Future prepare() {
     if (waitPaused) {
       Future<void> allPaused() async {
-        var vm = await vmService.getVM();
+        final vm = await vmService.getVM();
         for (var isolateRef in vm.isolates) {
-          var isolate = await isolateRef.load();
+          final isolate = await isolateRef.load();
           if (!isolate.isPaused) throw "Unpaused isolates remaining.";
         }
       }
@@ -167,7 +167,7 @@ class _OnExitCollector extends _CoverageCollector {
   @override
   Future collectCoverage() async {
     // Track all active isolates, also track isolates when they are started
-    var vm = await vmService.getVM();
+    final vm = await vmService.getVM();
     var allIsolatesAlreadyPaused = true;
 
     // Collection could have started at a time in which all isolates have

--- a/lib/src/collect.dart
+++ b/lib/src/collect.dart
@@ -225,7 +225,7 @@ class _OnExitCollector extends _CoverageCollector {
 
     if (!allIsolatesAlreadyPaused) {
       final isolateStartStream = service.onIsolateEvent
-          .where((e) => e.type == EventKind.kIsolateStart)
+          .where((e) => e.kind == EventKind.kIsolateStart)
           .map((e) => e.isolate);
       _isolateStartSubscription = isolateStartStream.listen(_trackIsolate);
 

--- a/lib/src/collect.dart
+++ b/lib/src/collect.dart
@@ -63,7 +63,6 @@ Future<Map<String, dynamic>> collect(
 
 Future<Map<String, dynamic>> _getAllCoverageOnExit(
     VMServiceClient service, bool resumeIsolates) async {
-
   Map<VMIsolateRef, StreamSubscription> _exitSubscriptions = {};
   var allCoverage = <Map<String, dynamic>>[];
   var completer = Completer<Map<String, dynamic>>();
@@ -73,7 +72,6 @@ Future<Map<String, dynamic>> _getAllCoverageOnExit(
     var sub = isolate.onPauseOrResume
         .where((event) => event is VMPauseExitEvent)
         .listen((event) async {
-          
       allCoverage.addAll(await _collectCoverage(service, isolate));
       await _exitSubscriptions.remove(isolate).cancel();
 

--- a/lib/src/collect.dart
+++ b/lib/src/collect.dart
@@ -24,9 +24,15 @@ const _retryInterval = Duration(milliseconds: 200);
 ///
 /// If [waitPaused] is true, collection will not begin until all isolates are
 /// in the paused state.
-Future<Map<String, dynamic>> collect(
-    Uri serviceUri, bool resume, bool waitPaused, bool onExit, bool includeDart,
-    {Duration timeout}) async {
+///
+/// If [onExit] is true, collection will be run for each isolate before its
+/// exists. If [onExit] is true, the [waitPaused] parameter will be ignored.
+Future<Map<String, dynamic>> collect(Uri serviceUri,
+    {bool resume = false,
+    bool waitPaused = false,
+    bool onExit = false,
+    bool includeDart = false,
+    Duration timeout}) async {
   _CoverageCollector collector;
   if (onExit) {
     collector =

--- a/lib/src/collect.dart
+++ b/lib/src/collect.dart
@@ -175,8 +175,9 @@ class _OnExitCollector extends _CoverageCollector {
     // isolates to start will take forever.
     for (var isolateRef in vm.isolates) {
       final isolatePaused = await _trackIsolate(isolateRef);
-      if (isolatePaused)
+      if (!isolatePaused) {
         allIsolatesAlreadyPaused = false;
+      }
     }
 
     if (!allIsolatesAlreadyPaused) {

--- a/lib/src/collect.dart
+++ b/lib/src/collect.dart
@@ -174,7 +174,9 @@ class _OnExitCollector extends _CoverageCollector {
     // already been paused before exiting. In that case, waiting for new
     // isolates to start will take forever.
     for (var isolateRef in vm.isolates) {
-      allIsolatesAlreadyPaused &= await _trackIsolate(isolateRef);
+      final isolatePaused = await _trackIsolate(isolateRef);
+      if (isolatePaused)
+        allIsolatesAlreadyPaused = false;
     }
 
     if (!allIsolatesAlreadyPaused) {

--- a/lib/src/run_and_collect.dart
+++ b/lib/src/run_and_collect.dart
@@ -55,7 +55,11 @@ Future<Map<String, dynamic>> runAndCollect(String scriptPath,
   final serviceUri = await serviceUriCompleter.future;
   Map<String, dynamic> coverage;
   try {
-    coverage = await collect(serviceUri, true, true, onExit, includeDart,
+    coverage = await collect(serviceUri,
+        resume: true,
+        waitPaused: true,
+        onExit: onExit,
+        includeDart: includeDart,
         timeout: timeout);
   } finally {
     await process.stderr.drain<List<int>>();

--- a/lib/src/run_and_collect.dart
+++ b/lib/src/run_and_collect.dart
@@ -12,6 +12,8 @@ import 'util.dart';
 Future<Map<String, dynamic>> runAndCollect(String scriptPath,
     {List<String> scriptArgs,
     bool checked = false,
+    bool onExit = false,
+    bool printOutput = false,
     String packageRoot,
     Duration timeout}) async {
   final dartArgs = [
@@ -39,6 +41,10 @@ Future<Map<String, dynamic>> runAndCollect(String scriptPath,
       .transform(utf8.decoder)
       .transform(const LineSplitter())
       .listen((line) {
+    if (printOutput) {
+      print(line);
+    }
+
     final uri = extractObservatoryUri(line);
     if (uri != null) {
       serviceUriCompleter.complete(uri);
@@ -48,7 +54,7 @@ Future<Map<String, dynamic>> runAndCollect(String scriptPath,
   final serviceUri = await serviceUriCompleter.future;
   Map<String, dynamic> coverage;
   try {
-    coverage = await collect(serviceUri, true, true, false, timeout: timeout);
+    coverage = await collect(serviceUri, true, true, onExit, timeout: timeout);
   } finally {
     await process.stderr.drain<List<int>>();
   }

--- a/lib/src/run_and_collect.dart
+++ b/lib/src/run_and_collect.dart
@@ -48,7 +48,7 @@ Future<Map<String, dynamic>> runAndCollect(String scriptPath,
   var serviceUri = await serviceUriCompleter.future;
   Map<String, dynamic> coverage;
   try {
-    coverage = await collect(serviceUri, true, true, timeout: timeout);
+    coverage = await collect(serviceUri, true, true, false, timeout: timeout);
   } finally {
     await process.stderr.drain<List<int>>();
   }

--- a/lib/src/util.dart
+++ b/lib/src/util.dart
@@ -5,13 +5,12 @@
 import 'dart:async';
 import 'dart:io';
 
-// TODO(cbracken) make generic
 /// Retries the specified function with the specified interval and returns
 /// the result on successful completion.
-Future<dynamic> retry(Future f(), Duration interval, {Duration timeout}) async {
+Future<T> retry<T>(Future<T> f(), Duration interval, {Duration timeout}) async {
   var keepGoing = true;
 
-  Future<dynamic> _withTimeout(Future f(), {Duration duration}) {
+  Future<T> _withTimeout<T>(Future<T> f(), {Duration duration}) {
     if (duration == null) {
       return f();
     }

--- a/test/collect_coverage_api_test.dart
+++ b/test/collect_coverage_api_test.dart
@@ -19,7 +19,7 @@ final _isolateLibFileUri = p.toUri(p.absolute(_isolateLibPath)).toString();
 
 void main() {
   test('collect throws when serviceUri is null', () {
-    expect(() => collect(null, true, false), throwsArgumentError);
+    expect(() => collect(null, true, false, false), throwsArgumentError);
   });
 
   test('collect_coverage_api', () async {
@@ -77,5 +77,5 @@ Future<Map<String, dynamic>> _collectCoverage() async {
   });
   Uri serviceUri = await serviceUriCompleter.future;
 
-  return collect(serviceUri, true, true, timeout: timeout);
+  return collect(serviceUri, true, true, false, timeout: timeout);
 }

--- a/test/collect_coverage_api_test.dart
+++ b/test/collect_coverage_api_test.dart
@@ -60,15 +60,15 @@ void _runTests(bool onExit) {
 Map _coverageData;
 Map _onExitCoverageData;
 
-Future<Map<String, dynamic>> _getCoverageResult([bool onExit = false]) async {
+Future<Map<String, dynamic>> _getCoverageResult(bool onExit) async {
   if (onExit) {
     return _onExitCoverageData ??= await _collectCoverage(true);
   } else {
-    return _coverageData ??= await _collectCoverage();
+    return _coverageData ??= await _collectCoverage(false);
   }
 }
 
-Future<Map<String, dynamic>> _collectCoverage([bool onExit = false]) async {
+Future<Map<String, dynamic>> _collectCoverage(bool onExit) async {
   var openPort = await getOpenPort();
 
   // run the sample app, with the right flags

--- a/test/collect_coverage_api_test.dart
+++ b/test/collect_coverage_api_test.dart
@@ -29,8 +29,7 @@ void main() {
 
 void _runTests(bool onExit) {
   test('collect throws when serviceUri is null', () {
-    expect(
-        () => collect(null, true, false, onExit, false), throwsArgumentError);
+    expect(() => collect(null, onExit: onExit), throwsArgumentError);
   });
 
   test('collect_coverage_api', () async {
@@ -90,5 +89,10 @@ Future<Map<String, dynamic>> _collectCoverage(bool onExit) async {
   });
   final Uri serviceUri = await serviceUriCompleter.future;
 
-  return collect(serviceUri, true, true, onExit, false, timeout: timeout);
+  return collect(serviceUri,
+      resume: true,
+      waitPaused: true,
+      onExit: onExit,
+      includeDart: false,
+      timeout: timeout);
 }

--- a/test/collect_coverage_test.dart
+++ b/test/collect_coverage_test.dart
@@ -151,20 +151,19 @@ Future<String> _collectCoverage(bool onExit) async {
 
   // Run the collection tool.
   // TODO: need to get all of this functionality in the lib
-  final toolResult = await Process.run('dart', [
+  final params = [
     _collectAppPath,
     '--uri',
     '$serviceUri',
     '--resume-isolates',
-    if (onExit)
-      '--on-exit'
-    else
-     '--wait-paused',
-  ]).timeout(timeout, onTimeout: () {
-    throw 'We timed out waiting for the tool to finish.';
-  });
+  ];
+  if (onExit) {
+    params.add('--on-exit');
+  } else {
+    params.add('--wait-paused');
+  }
 
-  var toolResult =
+  final toolResult =
       await Process.run('dart', params).timeout(timeout, onTimeout: () {
     throw 'We timed out waiting for the tool to finish.';
   });

--- a/test/lcov_test.dart
+++ b/test/lcov_test.dart
@@ -175,7 +175,7 @@ Future<Map> _getHitMap() async {
   Uri serviceUri = await serviceUriCompleter.future;
 
   // collect hit map.
-  List<Map> coverageJson = (await collect(serviceUri, true, true))['coverage'];
+  List<Map> coverageJson = (await collect(serviceUri, true, true, false))['coverage'];
   var hitMap = createHitmap(coverageJson);
 
   // wait for sample app to terminate.

--- a/test/lcov_test.dart
+++ b/test/lcov_test.dart
@@ -175,7 +175,8 @@ Future<Map> _getHitMap() async {
   Uri serviceUri = await serviceUriCompleter.future;
 
   // collect hit map.
-  List<Map> coverageJson = (await collect(serviceUri, true, true, false))['coverage'];
+  List<Map> coverageJson =
+      (await collect(serviceUri, true, true, false))['coverage'];
   var hitMap = createHitmap(coverageJson);
 
   // wait for sample app to terminate.

--- a/test/lcov_test.dart
+++ b/test/lcov_test.dart
@@ -175,8 +175,11 @@ Future<Map> _getHitMap() async {
   final Uri serviceUri = await serviceUriCompleter.future;
 
   // collect hit map.
-  final List<Map> coverageJson =
-      (await collect(serviceUri, true, true, false, false))['coverage'];
+  final List<Map> coverageJson = (await collect(serviceUri,
+      resume: true,
+      waitPaused: true,
+      onExit: false,
+      includeDart: false))['coverage'];
   final hitMap = createHitmap(coverageJson);
 
   // wait for sample app to terminate.

--- a/test/test_util.dart
+++ b/test/test_util.dart
@@ -14,7 +14,7 @@ const Duration timeout = const Duration(seconds: 20);
 Future<Process> runTestApp(int openPort) async {
   return Process.start('dart', [
     '--enable-vm-service=$openPort',
-    '--pause_isolates_on_exit',
+    '--pause-isolates-on-exit',
     testAppPath
   ]);
 }

--- a/test/util_test.dart
+++ b/test/util_test.dart
@@ -15,7 +15,7 @@ void main() {
     int count = 0;
     var stopwatch = new Stopwatch()..start();
 
-    Future failCountTimes() async {
+    Future<int> failCountTimes() async {
       expect(stopwatch.elapsed, greaterThanOrEqualTo(_delay * count));
 
       while (count < _failCount) {
@@ -37,7 +37,7 @@ void main() {
       int count = 0;
       var stopwatch = new Stopwatch()..start();
 
-      Future failCountTimes() async {
+      Future<int> failCountTimes() async {
         expect(stopwatch.elapsed, greaterThanOrEqualTo(_delay * count));
 
         while (count < _failCount) {
@@ -63,7 +63,7 @@ void main() {
       var caught = false;
       var countAfterError = 0;
 
-      Future failCountTimes() async {
+      Future<int> failCountTimes() async {
         if (caught) {
           countAfterError++;
         }


### PR DESCRIPTION
This implements the `on-exit` flag, which watches all isolates on the vm service and extracts coverage information when they exit. The collection process will complete when all isolates have finished.

This makes it easier to collect coverage for VM tests and builders. Instead of manually having to write test bundles that call all the `main` methods of test files sequentially in a single isolate, coverage can be collected on this script using `--on-exit`:
```dart
import 'package:test_core/src/executable.dart' as test;
import '../.dart_tool/build/entrypoint/build.dart' as builder;

void main() async {
  // Run the build runner
  await builder.main(['build', '--delete-conflicting-outputs']);
  // Run tests
  await test.main([]);
}
```
It wasn't possible to do this previously as the test runner will spawn another isolate for each test file, and the main isolate will only complete after the isolate for every test has completed. So, when running with `pause-isolates-on-exit` and `wait-paused`, the program will never reach a state in which all isolates are paused. However, if we collect coverage for each isolate as soon as it entered the `kPauseExit` state, the script will terminate after the coverage info for each isolate has been collected: We don't have to wait for _every_ isolate to be paused before starting to collect.

I extracted the collection process into two classes: `_OneTimeCollector`, which behaves like the existing process and `_OnExitCollector` which collects coverage whenever an isolate exits.