### PR TITLE
Migrate to Dart 2 typedefs and parameter defaults

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -62,7 +62,9 @@ linter:
     - overridden_fields
     - package_api_docs
     - package_prefixed_library_names
+    - prefer_equal_for_default_values
     # - prefer_final_locals
+    - prefer_generic_function_type_aliases
     - prefer_is_not_empty
     # - public_member_api_docs
     - slash_for_doc_comments

--- a/lib/src/formatter.dart
+++ b/lib/src/formatter.dart
@@ -114,7 +114,7 @@ class PrettyPrintFormatter implements Formatter {
 
 const _prefix = '       ';
 
-typedef bool _PathFilter(String path);
+typedef _PathFilter = bool Function(String path);
 
 _PathFilter _getPathFilter(List<String> reportOn) {
   if (reportOn == null) return (String path) => true;

--- a/lib/src/resolver.dart
+++ b/lib/src/resolver.dart
@@ -93,7 +93,7 @@ class Resolver {
 /// Bazel URI resolver.
 class BazelResolver extends Resolver {
   /// Creates a Bazel resolver with the specified workspace path, if any.
-  BazelResolver({this.workspacePath: ''});
+  BazelResolver({this.workspacePath = ''});
 
   final String workspacePath;
 

--- a/lib/src/run_and_collect.dart
+++ b/lib/src/run_and_collect.dart
@@ -11,7 +11,7 @@ import 'util.dart';
 
 Future<Map<String, dynamic>> runAndCollect(String scriptPath,
     {List<String> scriptArgs,
-    bool checked: false,
+    bool checked = false,
     String packageRoot,
     Duration timeout}) async {
   var dartArgs = [


### PR DESCRIPTION
Migrates the syntax introduced in Dart 2.0.0 for typedefs and optional
parameter default values. Adds lints to prevent regressions.