### PR TITLE
Skip dart: sources by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## dev
 
+ * BREAKING CHANGE: Skips collecting coverage for `dart:` libaries by default,
+   which provides a significant performance boost. To restore the previous
+   behaviour and collect coverage for these libraries, use the `--include-dart`
+   flag.
  * Disables WebSocket compression for coverage collection. Since almost all
    coverage collection runs happen over the loopback interface to localhost,
    this improves performance and reduces CPU usage.

--- a/bin/collect_coverage.dart
+++ b/bin/collect_coverage.dart
@@ -19,8 +19,8 @@ Future<Null> main(List<String> arguments) async {
 
   final options = _parseArgs(arguments);
   await Chain.capture(() async {
-    final coverage = await collect(
-        options.serviceUri, options.resume, options.waitPaused,
+    final coverage = await collect(options.serviceUri, options.resume,
+        options.waitPaused, options.includeDart,
         timeout: options.timeout);
     options.out.write(json.encode(coverage));
     await options.out.close();
@@ -34,14 +34,15 @@ Future<Null> main(List<String> arguments) async {
 }
 
 class Options {
-  Options(
-      this.serviceUri, this.out, this.timeout, this.waitPaused, this.resume);
+  Options(this.serviceUri, this.out, this.timeout, this.waitPaused, this.resume,
+      this.includeDart);
 
   final Uri serviceUri;
   final IOSink out;
   final Duration timeout;
   final bool waitPaused;
   final bool resume;
+  final bool includeDart;
 }
 
 Options _parseArgs(List<String> arguments) {
@@ -65,6 +66,8 @@ Options _parseArgs(List<String> arguments) {
         help: 'wait for all isolates to be paused before collecting coverage')
     ..addFlag('resume-isolates',
         abbr: 'r', defaultsTo: false, help: 'resume all isolates on exit')
+    ..addFlag('include-dart',
+        abbr: 'd', defaultsTo: false, help: 'include "dart:" libraries')
     ..addFlag('help', abbr: 'h', negatable: false, help: 'show this help');
 
   final args = parser.parse(arguments);
@@ -108,6 +111,6 @@ Options _parseArgs(List<String> arguments) {
   final timeout = (args['connect-timeout'] == null)
       ? null
       : Duration(seconds: int.parse(args['connect-timeout']));
-  return Options(
-      serviceUri, out, timeout, args['wait-paused'], args['resume-isolates']);
+  return Options(serviceUri, out, timeout, args['wait-paused'],
+      args['resume-isolates'], args['include-dart']);
 }

--- a/lib/src/run_and_collect.dart
+++ b/lib/src/run_and_collect.dart
@@ -13,6 +13,7 @@ Future<Map<String, dynamic>> runAndCollect(String scriptPath,
     {List<String> scriptArgs,
     bool checked = false,
     String packageRoot,
+    bool includeDart = false,
     Duration timeout}) async {
   final dartArgs = [
     '--enable-vm-service',
@@ -48,7 +49,8 @@ Future<Map<String, dynamic>> runAndCollect(String scriptPath,
   final serviceUri = await serviceUriCompleter.future;
   Map<String, dynamic> coverage;
   try {
-    coverage = await collect(serviceUri, true, true, timeout: timeout);
+    coverage =
+        await collect(serviceUri, true, true, includeDart, timeout: timeout);
   } finally {
     await process.stderr.drain<List<int>>();
   }

--- a/test/collect_coverage_api_test.dart
+++ b/test/collect_coverage_api_test.dart
@@ -19,7 +19,7 @@ final _isolateLibFileUri = p.toUri(p.absolute(_isolateLibPath)).toString();
 
 void main() {
   test('collect throws when serviceUri is null', () {
-    expect(() => collect(null, true, false), throwsArgumentError);
+    expect(() => collect(null, true, false, false), throwsArgumentError);
   });
 
   test('collect_coverage_api', () async {
@@ -77,5 +77,5 @@ Future<Map<String, dynamic>> _collectCoverage() async {
   });
   final Uri serviceUri = await serviceUriCompleter.future;
 
-  return collect(serviceUri, true, true, timeout: timeout);
+  return collect(serviceUri, true, true, false, timeout: timeout);
 }

--- a/test/lcov_test.dart
+++ b/test/lcov_test.dart
@@ -176,7 +176,7 @@ Future<Map> _getHitMap() async {
 
   // collect hit map.
   final List<Map> coverageJson =
-      (await collect(serviceUri, true, true))['coverage'];
+      (await collect(serviceUri, true, true, false))['coverage'];
   final hitMap = createHitmap(coverageJson);
 
   // wait for sample app to terminate.


### PR DESCRIPTION
Skips collecting coverage for VM scripts with URIs with scheme 'dart'.
There's a lot of this source, most users aren't interested in collecting
coverage for it, and those who do, can still get at it by passing the
`--include-dart` flag if they want it.

This cuts test runtime down to 36% of what it previously was.