### PR TITLE
Disable websocket compression on service port

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## dev
 
+ * Disables WebSocket compression for coverage collection. Since almost all
+   coverage collection runs happen over the loopback interface to localhost,
+   this improves performance and reduces CPU usage.
  * Migrates implementation of VM service protocol library from
    `package:vm_service_client`, which is no longer maintained, to
    `package:vm_service_lib`, which is.


### PR DESCRIPTION
This disables websocket compression when connecting to the VM service
port. Since almost all invocations of coverage collection tools happen
over a loopback connection to localhost, websocket compression uses a
ton of CPU, which causes a performance hit rather than a performance
benefit.