### PR TITLE
Handle null coverage range

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.13.1 - 2019-07-18
+
+ * Handle scenario where the VM returns empty coverage information for a range.
+
 ## 0.13.0 - 2019-07-10
 
  * BREAKING CHANGE: Skips collecting coverage for `dart:` libaries by default,

--- a/lib/src/collect.dart
+++ b/lib/src/collect.dart
@@ -164,6 +164,9 @@ Future<List<Map<String, dynamic>>> _getCoverageJson(VmService service,
 
     // Collect hits and misses.
     final coverage = range.coverage;
+
+    if (coverage == null) continue;
+
     for (final tokenPos in coverage.hits) {
       final line = _getLineFromTokenPos(script, tokenPos);
       if (line == null) {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: coverage
-version: 0.13.0
+version: 0.13.1
 author: Dart Team <misc@dartlang.org>
 description: Coverage data manipulation and formatting
 homepage: https://github.com/dart-lang/coverage


### PR DESCRIPTION
I'm not sure why the VM would return empty coverage information for a given range but it does in practice. Handle this situation so we don't randomly choke.