### PR TITLE
Support scoped output

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: dart
 
 dart:
-  - 2.0.0
+  - 2.1.1
   - dev
 
 install:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.13.2 - 2019-07-18
+
+ * Add new multi-flag option `--scope-output` which restricts coverage output
+   so that only scripts that start with the provided path are considered.
+
 ## 0.13.1 - 2019-07-18
 
  * Handle scenario where the VM returns empty coverage information for a range.

--- a/bin/collect_coverage.dart
+++ b/bin/collect_coverage.dart
@@ -20,7 +20,7 @@ Future<Null> main(List<String> arguments) async {
   final options = _parseArgs(arguments);
   await Chain.capture(() async {
     final coverage = await collect(options.serviceUri, options.resume,
-        options.waitPaused, options.includeDart,
+        options.waitPaused, options.includeDart, options.scopedOutput,
         timeout: options.timeout);
     options.out.write(json.encode(coverage));
     await options.out.close();
@@ -35,7 +35,7 @@ Future<Null> main(List<String> arguments) async {
 
 class Options {
   Options(this.serviceUri, this.out, this.timeout, this.waitPaused, this.resume,
-      this.includeDart);
+      this.includeDart, this.scopedOutput);
 
   final Uri serviceUri;
   final IOSink out;
@@ -43,6 +43,7 @@ class Options {
   final bool waitPaused;
   final bool resume;
   final bool includeDart;
+  final Set<String> scopedOutput;
 }
 
 Options _parseArgs(List<String> arguments) {
@@ -60,6 +61,9 @@ Options _parseArgs(List<String> arguments) {
         abbr: 'o', defaultsTo: 'stdout', help: 'output: may be file or stdout')
     ..addOption('connect-timeout',
         abbr: 't', help: 'connect timeout in seconds')
+    ..addMultiOption('scope-output',
+        help: 'restrict coverage results so that only scripts that start with '
+            'the provided path are considered')
     ..addFlag('wait-paused',
         abbr: 'w',
         defaultsTo: false,
@@ -101,6 +105,9 @@ Options _parseArgs(List<String> arguments) {
     }
   }
 
+  // ignore: avoid_as
+  final scopedOutput = args['scope-output'] as List<String> ?? [];
+
   IOSink out;
   if (args['out'] == 'stdout') {
     out = stdout;
@@ -112,5 +119,5 @@ Options _parseArgs(List<String> arguments) {
       ? null
       : Duration(seconds: int.parse(args['connect-timeout']));
   return Options(serviceUri, out, timeout, args['wait-paused'],
-      args['resume-isolates'], args['include-dart']);
+      args['resume-isolates'], args['include-dart'], scopedOutput.toSet());
 }

--- a/bin/collect_coverage.dart
+++ b/bin/collect_coverage.dart
@@ -63,7 +63,7 @@ Options _parseArgs(List<String> arguments) {
         abbr: 't', help: 'connect timeout in seconds')
     ..addMultiOption('scope-output',
         help: 'restrict coverage results so that only scripts that start with '
-            'the provided path are considered')
+            'the provided package path are considered')
     ..addFlag('wait-paused',
         abbr: 'w',
         defaultsTo: false,

--- a/lib/src/run_and_collect.dart
+++ b/lib/src/run_and_collect.dart
@@ -49,8 +49,8 @@ Future<Map<String, dynamic>> runAndCollect(String scriptPath,
   final serviceUri = await serviceUriCompleter.future;
   Map<String, dynamic> coverage;
   try {
-    coverage =
-        await collect(serviceUri, true, true, includeDart, timeout: timeout);
+    coverage = await collect(serviceUri, true, true, includeDart, Set<String>(),
+        timeout: timeout);
   } finally {
     await process.stderr.drain<List<int>>();
   }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: coverage
-version: 0.13.1
+version: 0.13.2
 author: Dart Team <misc@dartlang.org>
 description: Coverage data manipulation and formatting
 homepage: https://github.com/dart-lang/coverage

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -5,7 +5,7 @@ description: Coverage data manipulation and formatting
 homepage: https://github.com/dart-lang/coverage
 
 environment:
-  sdk: '>=2.0.0 <3.0.0'
+  sdk: '>=2.1.1 <3.0.0'
 
 dependencies:
   args: '>=1.4.0 <2.0.0'

--- a/test/lcov_test.dart
+++ b/test/lcov_test.dart
@@ -176,7 +176,7 @@ Future<Map> _getHitMap() async {
 
   // collect hit map.
   final List<Map> coverageJson =
-      (await collect(serviceUri, true, true, false))['coverage'];
+      (await collect(serviceUri, true, true, false, Set<String>()))['coverage'];
   final hitMap = createHitmap(coverageJson);
 
   // wait for sample app to terminate.


### PR DESCRIPTION
- Add new option `--scope-output` which restricts coverage output
  - This significantly improves performance when provided
- Add corresponding test
- Updated minimum sdk given the new service API call that only existed in `2.1.1+`

 cc @jonahwilliams