### PR TITLE
Migrated to pkg:vm_service

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 ## 0.13.3
 
- * Depend on `vm_service` instead of `vm_service_lib`.
+ * Migrates implementation of VM service protocol library from
+   `package:vm_service_lib`, which is no longer maintained, to
+   `package:vm_service`, which is.
 
 ## 0.13.2 - 2019-07-18
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.13.3
+
+ * Depend on `vm_service` instead of `vm_service_lib`.
+
 ## 0.13.2 - 2019-07-18
 
  * Add new multi-flag option `--scope-output` which restricts coverage output

--- a/lib/src/collect.dart
+++ b/lib/src/collect.dart
@@ -5,7 +5,7 @@
 import 'dart:async';
 import 'dart:io';
 
-import 'package:vm_service_lib/vm_service_lib.dart';
+import 'package:vm_service/vm_service.dart';
 
 import 'util.dart';
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: coverage
-version: 0.13.2
+version: 0.13.3-dev
 author: Dart Team <misc@dartlang.org>
 description: Coverage data manipulation and formatting
 homepage: https://github.com/dart-lang/coverage
@@ -13,7 +13,7 @@ dependencies:
   package_config: '>=0.1.5 <2.0.0'
   path: '>=0.9.0 <2.0.0'
   stack_trace: ^1.3.0
-  vm_service_lib: ^3.21.0
+  vm_service: ^1.0.0
 
 dev_dependencies:
   test: ^1.0.0


### PR DESCRIPTION
pkg:vm_service_lib is discontinued

Related to https://github.com/dart-lang/vm_service_drivers/issues/257