### PR TITLE
Document includeDart parameter on collect()

### DIFF
--- a/lib/src/collect.dart
+++ b/lib/src/collect.dart
@@ -25,6 +25,9 @@ const _retryInterval = Duration(milliseconds: 200);
 ///
 /// If [waitPaused] is true, collection will not begin until all isolates are
 /// in the paused state.
+///
+/// If [includeDart] is true, code coverage for core `dart:*` libraries will be
+/// collected.
 Future<Map<String, dynamic>> collect(Uri serviceUri, bool resume,
     bool waitPaused, bool includeDart, Set<String> scopedOutput,
     {Duration timeout}) async {


### PR DESCRIPTION
includeDart was added in 67b8249 (#257) as a means of controlling
whether coverage is collected for `dart:` libraries and should generally
be defaulted to false. This adds documentation for the parameter.