### PR TITLE
Bump version of vm_service

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: coverage
-version: 0.13.3
+version: 0.13.4
 author: Dart Team <misc@dartlang.org>
 description: Coverage data manipulation and formatting
 homepage: https://github.com/dart-lang/coverage
@@ -12,11 +12,11 @@ dependencies:
   logging: '>=0.9.0 <0.12.0'
   package_config: '>=0.1.5 <2.0.0'
   path: '>=0.9.0 <2.0.0'
-  stack_trace: ^1.3.0
-  vm_service: ^1.0.0
+  stack_trace: '^1.3.0'
+  vm_service: '^2.0.0'
 
 dev_dependencies:
-  test: ^1.0.0
+  test: '^1.0.0'
 
 executables:
   collect_coverage:


### PR DESCRIPTION
I noticed due to the recent update in `test` that coverage depends on a older version of vm_service where as `test` uses the latest.

One option, `coverage` could drop `vm_service` from pubspec.yaml and just depend on the transitive version used by `test`. If interest, I'll make that change to this PR.