### PR TITLE
Test that const decls are not marked coverable

### DIFF
--- a/test/collect_coverage_api_test.dart
+++ b/test/collect_coverage_api_test.dart
@@ -86,8 +86,8 @@ void main() {
     final Map<String, dynamic> isolateCoverage =
         _getScriptCoverage(coverage, 'test_app_isolate.dart');
     hits = isolateCoverage['hits'];
-    _expectHitCount(hits, 9, 1);
-    _expectHitCount(hits, 16, 1);
+    _expectHitCount(hits, 11, 1);
+    _expectHitCount(hits, 18, 1);
   });
 }
 

--- a/test/collect_coverage_test.dart
+++ b/test/collect_coverage_test.dart
@@ -57,31 +57,31 @@ void main() {
 
     final Map<int, int> isolateFile = hitMap[_isolateLibFileUri];
     final Map<int, int> expectedHits = {
-      10: 1,
-      11: 1,
-      13: 0,
-      17: 1,
-      18: 1,
-      20: 0,
-      27: 1,
+      12: 1,
+      13: 1,
+      15: 0,
+      19: 1,
+      20: 1,
+      22: 0,
       29: 1,
-      30: 2,
       31: 1,
-      32: 3,
+      32: 2,
       33: 1,
+      34: 3,
+      35: 1,
     };
     if (Platform.version.startsWith('1.')) {
       // Dart VMs prior to 2.0.0-dev.5.0 contain a bug that emits coverage on the
       // closing brace of async function blocks.
       // See: https://github.com/dart-lang/coverage/issues/196
-      expectedHits[21] = 0;
+      expectedHits[23] = 0;
     } else {
       // Dart VMs version 2.0.0-dev.6.0 mark the opening brace of a function as
       // coverable.
-      expectedHits[9] = 1;
-      expectedHits[16] = 1;
-      expectedHits[26] = 1;
-      expectedHits[30] = 3;
+      expectedHits[11] = 1;
+      expectedHits[18] = 1;
+      expectedHits[28] = 1;
+      expectedHits[32] = 3;
     }
     expect(isolateFile, expectedHits);
   });

--- a/test/run_and_collect_test.dart
+++ b/test/run_and_collect_test.dart
@@ -45,31 +45,31 @@ void main() {
 
     final Map<int, int> isolateFile = hitMap[_isolateLibFileUri];
     final Map<int, int> expectedHits = {
-      10: 1,
-      11: 1,
-      13: 0,
-      17: 1,
-      18: 1,
-      20: 0,
-      27: 1,
+      12: 1,
+      13: 1,
+      15: 0,
+      19: 1,
+      20: 1,
+      22: 0,
       29: 1,
-      30: 2,
       31: 1,
-      32: 3,
+      32: 2,
       33: 1,
+      34: 3,
+      35: 1,
     };
     // Dart VMs prior to 2.0.0-dev.5.0 contain a bug that emits coverage on the
     // closing brace of async function blocks.
     // See: https://github.com/dart-lang/coverage/issues/196
     if (Platform.version.startsWith('1.')) {
-      expectedHits[21] = 0;
+      expectedHits[23] = 0;
     } else {
       // Dart VMs version 2.0.0-dev.6.0 mark the opening brace of a function as
       // coverable.
-      expectedHits[9] = 1;
-      expectedHits[16] = 1;
-      expectedHits[26] = 1;
-      expectedHits[30] = 3;
+      expectedHits[11] = 1;
+      expectedHits[18] = 1;
+      expectedHits[28] = 1;
+      expectedHits[32] = 3;
     }
     expect(isolateFile, expectedHits);
   });

--- a/test/test_files/test_app_isolate.dart
+++ b/test/test_files/test_app_isolate.dart
@@ -6,15 +6,17 @@ import 'dart:async';
 import 'dart:io';
 import 'dart:isolate';
 
+const int answer = 42;
+
 String fooSync(int x) {
-  if (x == 42) {
+  if (x == answer) {
     return '*' * x;
   }
   return List.generate(x, (_) => 'xyzzy').join(' ');
 }
 
 Future<String> fooAsync(int x) async {
-  if (x == 42) {
+  if (x == answer) {
     return '*' * x;
   }
   return List.generate(x, (_) => 'xyzzy').join(' ');
@@ -26,8 +28,8 @@ Future<String> fooAsync(int x) async {
 void isolateTask(dynamic threeThings) {
   sleep(const Duration(milliseconds: 500));
 
-  fooSync(42);
-  fooAsync(42).then((_) {
+  fooSync(answer);
+  fooAsync(answer).then((_) {
     final SendPort port = threeThings.first;
     final int sum = threeThings[1] + threeThings[2];
     port.send(sum);


### PR DESCRIPTION
Constant declarations are evaluated during kernel compilation, not by
the VM. This patch adds a const to `test_app_isolate.dart` and verifies
that it doesn't appear in the coverage hitmap in
`collect_coverage_test.dart` and `run_and_collect_test.dart`.