### PR TITLE
Loosen version restriction on package:vm_service now that crasher has been fixed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 0.13.3+3 - 2019-12-03
+
+* Re-loosen the dependency on the `vm_service` package from `>=1.0.0 < 2.1.2`
+  to `>=1.0.0 <3.0.0` now that breakage introduced in version `2.1.2` has been
+  resolved. Fixed in:
+  https://github.com/dart-lang/sdk/commit/7a911ce3f1e945f2cbd1967c6109127e3acbab5a.
+
 ## 0.13.3+2 - 2019-12-02
 
 * Tighten the dependency on the `vm_service` package from `>=1.0.0 <3.0.0` down

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: coverage
-version: 0.13.3+2
+version: 0.13.3+3
 author: Dart Team <misc@dartlang.org>
 description: Coverage data manipulation and formatting
 homepage: https://github.com/dart-lang/coverage
@@ -13,7 +13,7 @@ dependencies:
   package_config: '>=0.1.5 <2.0.0'
   path: '>=0.9.0 <2.0.0'
   stack_trace: ^1.3.0
-  vm_service: '>=1.0.0 <2.1.2'
+  vm_service: '>=1.0.0 <3.0.0'
 
 dev_dependencies:
   test: ^1.0.0


### PR DESCRIPTION
See https://github.com/dart-lang/sdk/commit/7a911ce3f1e945f2cbd1967c6109127e3acbab5a

Fixes https://github.com/dart-lang/coverage/issues/278