### PR TITLE
Rename a variable for clarity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+## 0.13.6-dev
+
 ## 0.13.5 - 2020-01-30
 
 * Update `parseChromeCoverage` to merge coverage information for a given line.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: coverage
-version: 0.13.5
+version: 0.13.6-dev
 description: Coverage data manipulation and formatting
 homepage: https://github.com/dart-lang/coverage
 

--- a/test/run_and_collect_test.dart
+++ b/test/run_and_collect_test.dart
@@ -43,7 +43,7 @@ void main() {
     final hitMap = createHitmap(coverage);
     expect(hitMap, contains(_sampleAppFileUri));
 
-    final isolateFile = hitMap[_isolateLibFileUri];
+    final actualHits = hitMap[_isolateLibFileUri];
     final expectedHits = {
       12: 1,
       13: 1,
@@ -71,6 +71,6 @@ void main() {
       expectedHits[28] = 1;
       expectedHits[32] = 3;
     }
-    expect(isolateFile, expectedHits);
+    expect(actualHits, expectedHits);
   });
 }


### PR DESCRIPTION
A name based on what we are testing makes this more clear.