### PR TITLE
update the Resolver api to use the new package config api

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: dart
 
 dart:
-  - 2.6.0
+  - 2.7.0
   - dev
 
 install:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.13.7 - 2020-02-14
+
+* Update to package_config `1.9.0` which supports package_config.json
+  files and should be forwards compatible with `2.0.0`.
+
 ## 0.13.6 - 2020-02-10
 
 * Now consider all `.json` files for the `format_coverage` command.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 * Update to package_config `1.9.0` which supports package_config.json
   files and should be forwards compatible with `2.0.0`.
+* Deprecate the `packageRoot` argument on `Resolver`.
 
 ## 0.13.6 - 2020-02-10
 

--- a/bin/format_coverage.dart
+++ b/bin/format_coverage.dart
@@ -54,6 +54,7 @@ Future<Null> main(List<String> arguments) async {
       ? BazelResolver(workspacePath: env.bazelWorkspace)
       : Resolver(
           packagesPath: env.packagesPath,
+          // ignore_for_file: deprecated_member_use_from_same_package
           packageRoot: env.pkgRoot,
           sdkRoot: env.sdkRoot);
   final loader = Loader();

--- a/lib/src/resolver.dart
+++ b/lib/src/resolver.dart
@@ -103,14 +103,15 @@ class Resolver {
       final packageMap = <String, Uri>{};
       for (var line in lines) {
         if (line.startsWith('#')) continue;
-        final parts = line.split(':');
-        if (parts.length != 2) {
+        final firstColon = line.indexOf(':');
+        if (firstColon == -1) {
           throw FormatException(
               'Unexpected package config format, expected an old style '
               '.packages file or new style package_config.json file.',
               content);
         }
-        packageMap[parts.first] = Uri.parse(parts.last);
+        packageMap[line.substring(0, firstColon)] =
+            Uri.parse(line.substring(firstColon + 1, line.length));
       }
       return packageMap;
     }

--- a/lib/src/resolver.dart
+++ b/lib/src/resolver.dart
@@ -93,7 +93,8 @@ class Resolver {
   static Map<String, Uri> _parsePackages(String packagesPath) {
     final content = File(packagesPath).readAsStringSync();
     try {
-      final parsed = PackageConfig.parseString(content, Uri.file(packagesPath));
+      final parsed =
+          PackageConfig.parseString(content, Uri.base.resolve(packagesPath));
       return {
         for (var package in parsed.packages)
           package.name: package.packageUriRoot

--- a/lib/src/resolver.dart
+++ b/lib/src/resolver.dart
@@ -11,6 +11,7 @@ import 'package:path/path.dart' as p;
 
 /// [Resolver] resolves imports with respect to a given environment.
 class Resolver {
+  // ignore_for_file: deprecated_member_use_from_same_package
   Resolver({String packagesPath, @deprecated this.packageRoot, this.sdkRoot})
       : packagesPath = packagesPath,
         _packages = packagesPath != null ? _parsePackages(packagesPath) : null;

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -4,7 +4,7 @@ description: Coverage data manipulation and formatting
 homepage: https://github.com/dart-lang/coverage
 
 environment:
-  sdk: '>=2.6.0 <3.0.0'
+  sdk: '>=2.7.0 <3.0.0'
 
 dependencies:
   args: ^1.4.0

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -9,7 +9,7 @@ environment:
 dependencies:
   args: ^1.4.0
   logging: '>=0.9.0 <0.12.0'
-  package_config: ^0.1.9
+  package_config: ^1.9.0
   path: '>=0.9.0 <2.0.0'
   source_maps: ^0.10.8
   stack_trace: ^1.3.0
@@ -18,12 +18,6 @@ dependencies:
 dev_dependencies:
   pedantic: ^1.0.0
   test: ^1.0.0
-
-dependency_overrides:
-  package_config:
-    git:
-      url: https://github.com/dart-lang/package_config.git
-      ref: '1.9-allow-overlap'
 
 executables:
   collect_coverage:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: coverage
-version: 0.13.6
+version: 0.13.7
 description: Coverage data manipulation and formatting
 homepage: https://github.com/dart-lang/coverage
 
@@ -7,9 +7,9 @@ environment:
   sdk: '>=2.6.0 <3.0.0'
 
 dependencies:
-  args: '>=1.4.0 <2.0.0'
+  args: ^1.4.0
   logging: '>=0.9.0 <0.12.0'
-  package_config: '>=0.1.5 <2.0.0'
+  package_config: ^0.1.9
   path: '>=0.9.0 <2.0.0'
   source_maps: ^0.10.8
   stack_trace: ^1.3.0
@@ -18,6 +18,12 @@ dependencies:
 dev_dependencies:
   pedantic: ^1.0.0
   test: ^1.0.0
+
+dependency_overrides:
+  package_config:
+    git:
+      url: https://github.com/dart-lang/package_config.git
+      ref: '1.9-allow-overlap'
 
 executables:
   collect_coverage:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -18,6 +18,7 @@ dependencies:
 dev_dependencies:
   pedantic: ^1.0.0
   test: ^1.0.0
+  test_descriptor: ^1.2.0
 
 executables:
   collect_coverage:

--- a/test/resolver_test.dart
+++ b/test/resolver_test.dart
@@ -6,33 +6,58 @@ import 'dart:io';
 import 'dart:isolate';
 
 import 'package:coverage/src/resolver.dart';
+import 'package:path/path.dart' as p;
 import 'package:test/test.dart';
+import 'package:test_descriptor/test_descriptor.dart' as d;
 
 void main() {
   group('Default Resolver', () {
+    setUp(() async {
+      await d.dir('foo', [
+        d.file('.packages', '''
+# Fake for testing!
+foo:file:///${d.sandbox}/foo/lib
+'''),
+        d.file('.bad.packages', 'thisIsntAPackagesFile!'),
+        d.dir('.dart_tool', [
+          d.file('package_config.json', '''
+{
+  "configVersion": 2,
+  "packages": [
+    {
+      "name": "foo",
+      "rootUri": "file:///${d.sandbox}/foo",
+      "packageUri": "lib/"
+    }
+  ]
+}
+'''),
+        ]),
+        d.dir('lib', [
+          d.file('foo.dart', 'final foo = "bar";'),
+        ]),
+      ]).create();
+    });
+
     test('can be created from a package_config.json', () async {
-      final resolver = Resolver(packagesPath: '.dart_tool/package_config.json');
-      expect(
-          Uri.file(resolver.resolve('package:coverage/coverage.dart')),
-          await Isolate.resolvePackageUri(
-              Uri.parse('package:coverage/coverage.dart')));
+      final resolver = Resolver(
+          packagesPath:
+              p.join(d.sandbox, 'foo', '.dart_tool', 'package_config.json'));
+      expect(resolver.resolve('package:foo/foo.dart'),
+          '${d.sandbox}/foo/lib/foo.dart');
     });
 
     test('can be created from a .packages file', () async {
-      final resolver = Resolver(packagesPath: '.packages');
-      expect(
-          Uri.file(resolver.resolve('package:coverage/coverage.dart')),
-          await Isolate.resolvePackageUri(
-              Uri.parse('package:coverage/coverage.dart')));
+      final resolver =
+          Resolver(packagesPath: p.join(d.sandbox, 'foo', '.packages'));
+      expect(resolver.resolve('package:foo/foo.dart'),
+          '${d.sandbox}/foo/lib/foo.dart');
     });
 
     test('errors if the packagesFile is an unknown format', () async {
-      final tempDir = await Directory.systemTemp.createTemp('coverage_tests');
-      addTearDown(() => tempDir.delete(recursive: true));
-      final packagesFile = File.fromUri(tempDir.uri.resolve('.packages'));
-      await packagesFile.create();
-      await packagesFile.writeAsString('thisIsntAPackagesFile!');
-      expect(() => Resolver(packagesPath: packagesFile.path),
+      expect(
+          () =>
+              Resolver(packagesPath: p.join(d.sandbox, 'foo', '.bad.packages')),
           throwsA(isA<FormatException>()));
     });
   });

--- a/test/resolver_test.dart
+++ b/test/resolver_test.dart
@@ -2,10 +2,41 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+import 'dart:io';
+import 'dart:isolate';
+
 import 'package:coverage/src/resolver.dart';
 import 'package:test/test.dart';
 
 void main() {
+  group('Default Resolver', () {
+    test('can be created from a package_config.json', () async {
+      final resolver = Resolver(packagesPath: '.dart_tool/package_config.json');
+      expect(
+          Uri.file(resolver.resolve('package:coverage/coverage.dart')),
+          await Isolate.resolvePackageUri(
+              Uri.parse('package:coverage/coverage.dart')));
+    });
+
+    test('can be created from a .packages file', () async {
+      final resolver = Resolver(packagesPath: '.packages');
+      expect(
+          Uri.file(resolver.resolve('package:coverage/coverage.dart')),
+          await Isolate.resolvePackageUri(
+              Uri.parse('package:coverage/coverage.dart')));
+    });
+
+    test('errors if the packagesFile is an unknown format', () async {
+      final tempDir = await Directory.systemTemp.createTemp('coverage_tests');
+      addTearDown(() => tempDir.delete(recursive: true));
+      final packagesFile = File.fromUri(tempDir.uri.resolve('.packages'));
+      await packagesFile.create();
+      await packagesFile.writeAsString('thisIsntAPackagesFile!');
+      expect(() => Resolver(packagesPath: packagesFile.path),
+          throwsA(isA<FormatException>()));
+    });
+  });
+
   group('Bazel resolver', () {
     const workspace = 'foo';
     final resolver = BazelResolver(workspacePath: workspace);


### PR DESCRIPTION
Closes https://github.com/dart-lang/tools/issues/459.

Blocked on https://github.com/dart-lang/package_config/issues/68 and a published version of package_config.