### PR TITLE
Remove unused dart:async imports

### DIFF
--- a/lib/src/formatter.dart
+++ b/lib/src/formatter.dart
@@ -2,8 +2,6 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'dart:async';
-
 import 'package:path/path.dart' as p;
 
 import 'resolver.dart';

--- a/lib/src/hitmap.dart
+++ b/lib/src/hitmap.dart
@@ -2,7 +2,6 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'dart:async';
 import 'dart:convert' show json;
 import 'dart:io';
 

--- a/lib/src/resolver.dart
+++ b/lib/src/resolver.dart
@@ -2,7 +2,6 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'dart:async';
 import 'dart:convert';
 import 'dart:io';
 

--- a/lib/src/util.dart
+++ b/lib/src/util.dart
@@ -2,7 +2,6 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'dart:async';
 import 'dart:io';
 
 // TODO(cbracken) make generic


### PR DESCRIPTION
Since this version does not support Dart 1.0, these imports are
unnecessary.