### PR TITLE
Fix --wait-paused with no isolates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.14.2 - UNRELEASED 
+
+* Fix an issue where `--wait-paused` with `collect` would attempt to collect coverage
+  if no isolates have started.
+
 ## 0.14.1 - 2020-09-10
 
 * Updated dependency on `vm_service` package from `>=1.0.0 < 5.0.0` to `>=1.0.0 <6.0.0`.

--- a/lib/src/collect.dart
+++ b/lib/src/collect.dart
@@ -148,6 +148,7 @@ Future _waitIsolatesPaused(VmService service, {Duration timeout}) async {
 
   Future allPaused() async {
     final vm = await service.getVM();
+    if (vm.isolates.isEmpty) throw 'No isolates.';
     for (var isolateRef in vm.isolates) {
       final isolate = await service.getIsolate(isolateRef.id);
       if (!pauseEvents.contains(isolate.pauseEvent.kind)) {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: coverage
-version: 0.14.1
+version: 0.14.2
 description: Coverage data manipulation and formatting
 homepage: https://github.com/dart-lang/coverage
 


### PR DESCRIPTION
Closes https://github.com/dart-lang/coverage/issues/309

There was a race condition in our logic which was exacerbated by SDK version `2.10`. If no isolates had started, we wouldn't properly wait to collect coverage information.