### PR TITLE
Remove unused dart:async import

### DIFF
--- a/bin/format_coverage.dart
+++ b/bin/format_coverage.dart
@@ -2,7 +2,6 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'dart:async';
 import 'dart:io';
 
 import 'package:args/args.dart';


### PR DESCRIPTION
Since Dart 2.1, Future and Stream have been exported from dart:core