### PR TITLE
Remove unnecessary dart:async imports

### DIFF
--- a/bin/collect_coverage.dart
+++ b/bin/collect_coverage.dart
@@ -2,7 +2,6 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'dart:async';
 import 'dart:convert' show json;
 import 'dart:io';
 

--- a/bin/collect_coverage.dart
+++ b/bin/collect_coverage.dart
@@ -1,7 +1,7 @@
 // Copyright (c) 2014, the Dart project authors.  Please see the AUTHORS file
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
-
+ 
 import 'dart:convert' show json;
 import 'dart:io';
 

--- a/bin/collect_coverage.dart
+++ b/bin/collect_coverage.dart
@@ -1,7 +1,7 @@
 // Copyright (c) 2014, the Dart project authors.  Please see the AUTHORS file
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
- 
+
 import 'dart:convert' show json;
 import 'dart:io';
 

--- a/test/util_test.dart
+++ b/test/util_test.dart
@@ -2,8 +2,6 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'dart:async';
-
 import 'package:coverage/src/util.dart';
 import 'package:test/test.dart';
 


### PR DESCRIPTION
As of Dart 2.1, Future/Stream have been exported from dart:core.