### PR TITLE
Remove packageRoot in run_and_collect

### DIFF
--- a/bin/format_coverage.dart
+++ b/bin/format_coverage.dart
@@ -11,7 +11,6 @@ import 'package:path/path.dart' as p;
 /// [Environment] stores gathered arguments information.
 class Environment {
   String sdkRoot;
-  String pkgRoot;
   String packagesPath;
   String baseDirectory;
   String input;
@@ -36,7 +35,6 @@ Future<Null> main(List<String> arguments) async {
     print('  # files: ${files.length}');
     print('  # workers: ${env.workers}');
     print('  sdk-root: ${env.sdkRoot}');
-    print('  package-root: ${env.pkgRoot}');
     print('  package-spec: ${env.packagesPath}');
     print('  report-on: ${env.reportOn}');
     print('  check-ignore: ${env.checkIgnore}');
@@ -59,8 +57,6 @@ Future<Null> main(List<String> arguments) async {
       ? BazelResolver(workspacePath: env.bazelWorkspace)
       : Resolver(
           packagesPath: env.packagesPath,
-          // ignore_for_file: deprecated_member_use_from_same_package
-          packageRoot: env.pkgRoot,
           sdkRoot: env.sdkRoot);
   final loader = Loader();
   if (env.prettyPrint) {
@@ -104,7 +100,6 @@ Environment parseArgs(List<String> arguments) {
   final parser = ArgParser();
 
   parser.addOption('sdk-root', abbr: 's', help: 'path to the SDK root');
-  parser.addOption('package-root', abbr: 'p', help: 'path to the package root');
   parser.addOption('packages', help: 'path to the package spec file');
   parser.addOption('in', abbr: 'i', help: 'input(s): may be file or directory');
   parser.addOption('out',
@@ -166,22 +161,10 @@ Environment parseArgs(List<String> arguments) {
     }
   }
 
-  if (args['package-root'] != null && args['packages'] != null) {
-    fail('Only one of --package-root or --packages may be specified.');
-  }
-
   env.packagesPath = args['packages'] as String;
   if (env.packagesPath != null) {
     if (!FileSystemEntity.isFileSync(env.packagesPath)) {
       fail('Package spec "${args["packages"]}" not found, or not a file.');
-    }
-  }
-
-  env.pkgRoot = args['package-root'] as String;
-  if (env.pkgRoot != null) {
-    env.pkgRoot = p.absolute(p.normalize(args['package-root'] as String));
-    if (!FileSystemEntity.isDirectorySync(env.pkgRoot)) {
-      fail('Package root "${args["package-root"]}" is not a directory.');
     }
   }
 

--- a/bin/run_and_collect.dart
+++ b/bin/run_and_collect.dart
@@ -7,6 +7,6 @@ import 'dart:async';
 import 'package:coverage/src/run_and_collect.dart';
 
 Future<Null> main(List<String> args) async {
-  final Map results = await runAndCollect(args[0], packageRoot: args[1]);
+  final Map results = await runAndCollect(args[0]);
   print(results);
 }

--- a/lib/src/resolver.dart
+++ b/lib/src/resolver.dart
@@ -10,13 +10,11 @@ import 'package:path/path.dart' as p;
 
 /// [Resolver] resolves imports with respect to a given environment.
 class Resolver {
-  // ignore_for_file: deprecated_member_use_from_same_package
-  Resolver({String packagesPath, @deprecated this.packageRoot, this.sdkRoot})
+  Resolver({String packagesPath, this.sdkRoot})
       : packagesPath = packagesPath,
         _packages = packagesPath != null ? _parsePackages(packagesPath) : null;
 
   final String packagesPath;
-  final String packageRoot;
   final String sdkRoot;
   final List<String> failed = [];
   final Map<String, Uri> _packages;
@@ -55,23 +53,19 @@ class Resolver {
       return resolveSymbolicLinks(filePath);
     }
     if (uri.scheme == 'package') {
-      if (packagesPath == null && packageRoot == null) {
-        // No package-root given, do not resolve package: URIs.
+      if (_packages == null) {
         return null;
       }
 
       final packageName = uri.pathSegments[0];
-      if (_packages != null) {
-        final packageUri = _packages[packageName];
-        if (packageUri == null) {
-          failed.add('$uri');
-          return null;
-        }
-        final packagePath = p.fromUri(packageUri);
-        final pathInPackage = p.joinAll(uri.pathSegments.sublist(1));
-        return resolveSymbolicLinks(p.join(packagePath, pathInPackage));
+      final packageUri = _packages[packageName];
+      if (packageUri == null) {
+        failed.add('$uri');
+        return null;
       }
-      return resolveSymbolicLinks(p.join(packageRoot, uri.path));
+      final packagePath = p.fromUri(packageUri);
+      final pathInPackage = p.joinAll(uri.pathSegments.sublist(1));
+      return resolveSymbolicLinks(p.join(packagePath, pathInPackage));
     }
     if (uri.scheme == 'file') {
       return resolveSymbolicLinks(p.fromUri(uri));

--- a/lib/src/run_and_collect.dart
+++ b/lib/src/run_and_collect.dart
@@ -12,7 +12,6 @@ import 'util.dart';
 Future<Map<String, dynamic>> runAndCollect(String scriptPath,
     {List<String> scriptArgs,
     bool checked = false,
-    String packageRoot,
     bool includeDart = false,
     Duration timeout}) async {
   final dartArgs = [
@@ -22,10 +21,6 @@ Future<Map<String, dynamic>> runAndCollect(String scriptPath,
 
   if (checked) {
     dartArgs.add('--checked');
-  }
-
-  if (packageRoot != null) {
-    dartArgs.add('--package-root=$packageRoot');
   }
 
   dartArgs.add(scriptPath);


### PR DESCRIPTION
`--package-root=` is discontinued in dart.
(https://github.com/dart-lang/sdk/issues/41197)