### PR TITLE
Prep to publish 0.15.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 0.15.0 - 2021-01-13
+
+* BREAKING CHANGE: Eliminate the `--package-root` option from
+  `bin/run_and_collect.dart` and `bin/format_coverage.dart` as well as
+  from `runAndCollect` and the `Resolver` constructor.
+
 ## 0.14.2 - 2020-11-10
 
 * Fix an issue where `--wait-paused` with `collect` would attempt to collect coverage

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -21,9 +21,9 @@ dev_dependencies:
   test_descriptor: ^1.2.0
 
 dependency_overrides:
-  test: ^1.16.0-nullsafety.4
-  test_core: 0.3.12-nullsafety.5
-  test_api: '>=0.2.19-nullsafety <0.2.19-nullsafety.4'
+  test: 1.16.0-nullsafety.13 
+  test_core: 0.3.12-nullsafety.12
+  test_api: 0.2.19-nullsafety.6 
 
 executables:
   collect_coverage:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -20,6 +20,11 @@ dev_dependencies:
   test: ^1.16.0-nullsafety.4
   test_descriptor: ^1.2.0
 
+dependency_overrides:
+  test: ^1.16.0-nullsafety.4
+  test_core: 0.3.12-nullsafety.5
+  test_api: '>=0.2.19-nullsafety <0.2.19-nullsafety.4'
+
 executables:
   collect_coverage:
   format_coverage:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: coverage
-version: 0.14.2
+version: 0.15.0
 description: Coverage data manipulation and formatting
 homepage: https://github.com/dart-lang/coverage
 


### PR DESCRIPTION
Eliminates the `--package-root` option from both run_and_collect and
format_coverage commands, as well as from non-public API under lib/src.

Related patch #324 by @lukaslihotzki. 