### PR TITLE
update several deps to allow the latest stable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.15.2 - 2021-02-08
+
+* Update `args`, `logging`, and `package_config` deps to allow the latest
+  stable releases.
+
 ## 0.15.1 - 2021-01-14
 
 * Updated dependency on `vm_service` package from `>=1.0.0 < 5.0.0` to `>=1.0.0 <7.0.0`.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: coverage
-version: 0.15.1
+version: 0.15.2
 description: Coverage data manipulation and formatting
 homepage: https://github.com/dart-lang/coverage
 
@@ -7,9 +7,9 @@ environment:
   sdk: '>=2.7.0 <3.0.0'
 
 dependencies:
-  args: ^1.4.0
-  logging: '>=0.9.0 <0.12.0'
-  package_config: ^1.9.0
+  args: '>=1.4.0 <3.0.0'
+  logging: '>=0.9.0 <2.0.0'
+  package_config: '>=1.9.0 <3.0.0'
   path: '>=0.9.0 <2.0.0'
   source_maps: ^0.10.8
   stack_trace: ^1.3.0
@@ -18,8 +18,7 @@ dependencies:
 dev_dependencies:
   pedantic: ^1.0.0
   test: ^1.16.0-nullsafety.4
-  test_descriptor: ^1.2.0
-
+  test_descriptor: ^2.0.0-nullsafety
 executables:
   collect_coverage:
   format_coverage:


### PR DESCRIPTION
cc @pq 

Note that getting the latest `logging` is blocked on https://github.com/google/webkit_inspection_protocol.dart/pull/65.