### PR TITLE
migrate to null safety

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.0.0 - 2021-02-25
+
+* Migrate to null safety.
+
 ## 0.15.2 - 2021-02-08
 
 * Update `args`, `logging`, and `package_config` deps to allow the latest

--- a/bin/collect_coverage.dart
+++ b/bin/collect_coverage.dart
@@ -39,7 +39,7 @@ class Options {
 
   final Uri serviceUri;
   final IOSink out;
-  final Duration timeout;
+  final Duration? timeout;
   final bool waitPaused;
   final bool resume;
   final bool includeDart;
@@ -81,7 +81,7 @@ Options _parseArgs(List<String> arguments) {
     print(parser.usage);
   }
 
-  void fail(String message) {
+  Never fail(String message) {
     print('Error: $message\n');
     printUsage();
     exit(1);
@@ -105,8 +105,7 @@ Options _parseArgs(List<String> arguments) {
     }
   }
 
-  final scopedOutput = args['scope-output'] as List<String> ?? [];
-
+  final scopedOutput = args['scope-output'] as List<String>;
   IOSink out;
   if (args['out'] == 'stdout') {
     out = stdout;

--- a/lib/src/collect.dart
+++ b/lib/src/collect.dart
@@ -35,17 +35,16 @@ const _retryInterval = Duration(milliseconds: 200);
 /// if [isolateIds] is set, the coverage gathering will be restricted to only
 /// those VM isolates.
 Future<Map<String, dynamic>> collect(Uri serviceUri, bool resume,
-    bool waitPaused, bool includeDart, Set<String> scopedOutput,
-    {Set<String> isolateIds, Duration timeout}) async {
+    bool waitPaused, bool includeDart, Set<String>? scopedOutput,
+    {Set<String>? isolateIds, Duration? timeout}) async {
   scopedOutput ??= <String>{};
-  if (serviceUri == null) throw ArgumentError('serviceUri must not be null');
 
   // Create websocket URI. Handle any trailing slashes.
   final pathSegments =
       serviceUri.pathSegments.where((c) => c.isNotEmpty).toList()..add('ws');
   final uri = serviceUri.replace(scheme: 'ws', pathSegments: pathSegments);
 
-  VmService service;
+  late VmService service;
   await retry(() async {
     try {
       final options = const CompressionOptions(enabled: false);
@@ -83,24 +82,27 @@ Future<Map<String, dynamic>> collect(Uri serviceUri, bool resume,
   }
 }
 
-Future<Map<String, dynamic>> _getAllCoverage(VmService service,
-    bool includeDart, Set<String> scopedOutput, Set<String> isolateIds) async {
+Future<Map<String, dynamic>> _getAllCoverage(
+    VmService service,
+    bool includeDart,
+    Set<String>? scopedOutput,
+    Set<String>? isolateIds) async {
   scopedOutput ??= <String>{};
   final vm = await service.getVM();
   final allCoverage = <Map<String, dynamic>>[];
 
-  for (var isolateRef in vm.isolates) {
+  for (var isolateRef in vm.isolates!) {
     if (isolateIds != null && !isolateIds.contains(isolateRef.id)) continue;
     if (scopedOutput.isNotEmpty) {
-      final scripts = await service.getScripts(isolateRef.id);
-      for (var script in scripts.scripts) {
-        final uri = Uri.parse(script.uri);
+      final scripts = await service.getScripts(isolateRef.id!);
+      for (var script in scripts.scripts!) {
+        final uri = Uri.parse(script.uri!);
         if (uri.scheme != 'package') continue;
         final scope = uri.path.split('/').first;
         // Skip scripts which should not be included in the report.
         if (!scopedOutput.contains(scope)) continue;
         final scriptReport = await service.getSourceReport(
-            isolateRef.id, <String>[SourceReportKind.kCoverage],
+            isolateRef.id!, <String>[SourceReportKind.kCoverage],
             forceCompile: true, scriptId: script.id);
         final coverage = await _getCoverageJson(
             service, isolateRef, scriptReport, includeDart);
@@ -108,7 +110,7 @@ Future<Map<String, dynamic>> _getAllCoverage(VmService service,
       }
     } else {
       final isolateReport = await service.getSourceReport(
-        isolateRef.id,
+        isolateRef.id!,
         <String>[SourceReportKind.kCoverage],
         forceCompile: true,
       );
@@ -123,14 +125,14 @@ Future<Map<String, dynamic>> _getAllCoverage(VmService service,
 Future _resumeIsolates(VmService service) async {
   final vm = await service.getVM();
   final futures = <Future>[];
-  for (var isolateRef in vm.isolates) {
+  for (var isolateRef in vm.isolates!) {
     // Guard against sync as well as async errors: sync - when we are writing
     // message to the socket, the socket might be closed; async - when we are
     // waiting for the response, the socket again closes.
     futures.add(Future.sync(() async {
-      final isolate = await service.getIsolate(isolateRef.id);
-      if (isolate.pauseEvent.kind != EventKind.kResume) {
-        await service.resume(isolateRef.id);
+      final isolate = await service.getIsolate(isolateRef.id!);
+      if (isolate.pauseEvent!.kind != EventKind.kResume) {
+        await service.resume(isolateRef.id!);
       }
     }));
   }
@@ -141,7 +143,7 @@ Future _resumeIsolates(VmService service) async {
   }
 }
 
-Future _waitIsolatesPaused(VmService service, {Duration timeout}) async {
+Future _waitIsolatesPaused(VmService service, {Duration? timeout}) async {
   final pauseEvents = <String>{
     EventKind.kPauseStart,
     EventKind.kPauseException,
@@ -152,10 +154,10 @@ Future _waitIsolatesPaused(VmService service, {Duration timeout}) async {
 
   Future allPaused() async {
     final vm = await service.getVM();
-    if (vm.isolates.isEmpty) throw 'No isolates.';
-    for (var isolateRef in vm.isolates) {
-      final isolate = await service.getIsolate(isolateRef.id);
-      if (!pauseEvents.contains(isolate.pauseEvent.kind)) {
+    if (vm.isolates!.isEmpty) throw 'No isolates.';
+    for (var isolateRef in vm.isolates!) {
+      final isolate = await service.getIsolate(isolateRef.id!);
+      if (!pauseEvents.contains(isolate.pauseEvent!.kind)) {
         throw 'Unpaused isolates remaining.';
       }
     }
@@ -168,14 +170,14 @@ Future _waitIsolatesPaused(VmService service, {Duration timeout}) async {
 ///
 /// Performs a binary search within the script's token position table to locate
 /// the line in question.
-int _getLineFromTokenPos(Script script, int tokenPos) {
+int? _getLineFromTokenPos(Script script, int tokenPos) {
   // TODO(cbracken): investigate whether caching this lookup results in
   // significant performance gains.
   var min = 0;
-  var max = script.tokenPosTable.length;
+  var max = script.tokenPosTable!.length;
   while (min < max) {
     final mid = min + ((max - min) >> 1);
-    final row = script.tokenPosTable[mid];
+    final row = script.tokenPosTable![mid];
     if (row[1] > tokenPos) {
       max = mid;
     } else {
@@ -194,9 +196,9 @@ Future<List<Map<String, dynamic>>> _getCoverageJson(VmService service,
   // script uri -> { line -> hit count }
   final hitMaps = <Uri, Map<int, int>>{};
   final scripts = <ScriptRef, Script>{};
-  for (var range in report.ranges) {
-    final scriptRef = report.scripts[range.scriptIndex];
-    final scriptUri = Uri.parse(report.scripts[range.scriptIndex].uri);
+  for (var range in report.ranges!) {
+    final scriptRef = report.scripts![range.scriptIndex!];
+    final scriptUri = Uri.parse(report.scripts![range.scriptIndex!].uri!);
 
     // Not returned in scripts section of source report.
     if (scriptUri.scheme == 'evaluate') continue;
@@ -206,9 +208,10 @@ Future<List<Map<String, dynamic>>> _getCoverageJson(VmService service,
 
     if (!scripts.containsKey(scriptRef)) {
       scripts[scriptRef] =
-          await service.getObject(isolateRef.id, scriptRef.id) as Script;
+          await service.getObject(isolateRef.id!, scriptRef.id!) as Script;
     }
     final script = scripts[scriptRef];
+    if (script == null) continue;
 
     // Look up the hit map for this script (shared across isolates).
     final hitMap = hitMaps.putIfAbsent(scriptUri, () => <int, int>{});
@@ -218,17 +221,19 @@ Future<List<Map<String, dynamic>>> _getCoverageJson(VmService service,
 
     if (coverage == null) continue;
 
-    for (final tokenPos in coverage.hits) {
+    for (final tokenPos in coverage.hits!) {
       final line = _getLineFromTokenPos(script, tokenPos);
       if (line == null) {
         print('tokenPos $tokenPos has no line mapping for script $scriptUri');
+        continue;
       }
-      hitMap[line] = hitMap.containsKey(line) ? hitMap[line] + 1 : 1;
+      hitMap[line] = hitMap.containsKey(line) ? hitMap[line]! + 1 : 1;
     }
-    for (final tokenPos in coverage.misses) {
+    for (final tokenPos in coverage.misses!) {
       final line = _getLineFromTokenPos(script, tokenPos);
       if (line == null) {
         print('tokenPos $tokenPos has no line mapping for script $scriptUri');
+        continue;
       }
       hitMap.putIfAbsent(line, () => 0);
     }

--- a/lib/src/formatter.dart
+++ b/lib/src/formatter.dart
@@ -25,15 +25,15 @@ class LcovFormatter implements Formatter {
   LcovFormatter(this.resolver, {this.reportOn, this.basePath});
 
   final Resolver resolver;
-  final String basePath;
-  final List<String> reportOn;
+  final String? basePath;
+  final List<String>? reportOn;
 
   @override
   Future<String> format(Map<String, Map<int, int>> hitmap) async {
     final pathFilter = _getPathFilter(reportOn);
     final buf = StringBuffer();
     for (var key in hitmap.keys) {
-      final v = hitmap[key];
+      final v = hitmap[key]!;
       var source = resolver.resolve(key);
       if (source == null) {
         continue;
@@ -53,7 +53,7 @@ class LcovFormatter implements Formatter {
         buf.write('DA:$k,${v[k]}\n');
       }
       buf.write('LF:${lines.length}\n');
-      buf.write('LH:${lines.where((k) => v[k] > 0).length}\n');
+      buf.write('LH:${lines.where((k) => v[k]! > 0).length}\n');
       buf.write('end_of_record\n');
     }
 
@@ -75,7 +75,7 @@ class PrettyPrintFormatter implements Formatter {
 
   final Resolver resolver;
   final Loader loader;
-  final List<String> reportOn;
+  final List<String>? reportOn;
 
   @override
   Future<String> format(Map<String, dynamic> hitmap) async {
@@ -114,7 +114,7 @@ const _prefix = '       ';
 
 typedef _PathFilter = bool Function(String path);
 
-_PathFilter _getPathFilter(List<String> reportOn) {
+_PathFilter _getPathFilter(List<String>? reportOn) {
   if (reportOn == null) return (String path) => true;
 
   final absolutePaths = reportOn.map(p.absolute).toList();

--- a/lib/src/resolver.dart
+++ b/lib/src/resolver.dart
@@ -10,20 +10,21 @@ import 'package:path/path.dart' as p;
 
 /// [Resolver] resolves imports with respect to a given environment.
 class Resolver {
-  Resolver({String packagesPath, this.sdkRoot})
+  Resolver({String? packagesPath, this.sdkRoot})
       : packagesPath = packagesPath,
         _packages = packagesPath != null ? _parsePackages(packagesPath) : null;
 
-  final String packagesPath;
-  final String sdkRoot;
+  final String? packagesPath;
+  final String? sdkRoot;
   final List<String> failed = [];
-  final Map<String, Uri> _packages;
+  final Map<String, Uri>? _packages;
 
   /// Returns the absolute path wrt. to the given environment or null, if the
   /// import could not be resolved.
-  String resolve(String scriptUri) {
+  String? resolve(String scriptUri) {
     final uri = Uri.parse(scriptUri);
     if (uri.scheme == 'dart') {
+      final sdkRoot = this.sdkRoot;
       if (sdkRoot == null) {
         // No sdk-root given, do not resolve dart: URIs.
         return null;
@@ -53,6 +54,7 @@ class Resolver {
       return resolveSymbolicLinks(filePath);
     }
     if (uri.scheme == 'package') {
+      final _packages = this._packages;
       if (_packages == null) {
         return null;
       }
@@ -76,7 +78,7 @@ class Resolver {
   }
 
   /// Returns a canonicalized path, or `null` if the path cannot be resolved.
-  String resolveSymbolicLinks(String path) {
+  String? resolveSymbolicLinks(String path) {
     final normalizedPath = p.normalize(path);
     final type = FileSystemEntity.typeSync(normalizedPath, followLinks: true);
     if (type == FileSystemEntityType.notFound) return null;
@@ -123,7 +125,7 @@ class BazelResolver extends Resolver {
   /// Returns the absolute path wrt. to the given environment or null, if the
   /// import could not be resolved.
   @override
-  String resolve(String scriptUri) {
+  String? resolve(String scriptUri) {
     final uri = Uri.parse(scriptUri);
     if (uri.scheme == 'dart') {
       // Ignore the SDK
@@ -177,7 +179,7 @@ class Loader {
 
   /// Loads an imported resource and returns a [Future] with a [List] of lines.
   /// Returns `null` if the resource could not be loaded.
-  Future<List<String>> load(String path) async {
+  Future<List<String>?> load(String path) async {
     try {
       // Ensure `readAsLines` runs within the try block so errors are caught.
       return await File(path).readAsLines();

--- a/lib/src/run_and_collect.dart
+++ b/lib/src/run_and_collect.dart
@@ -10,10 +10,10 @@ import 'collect.dart';
 import 'util.dart';
 
 Future<Map<String, dynamic>> runAndCollect(String scriptPath,
-    {List<String> scriptArgs,
+    {List<String>? scriptArgs,
     bool checked = false,
     bool includeDart = false,
-    Duration timeout}) async {
+    Duration? timeout}) async {
   final dartArgs = [
     '--enable-vm-service',
     '--pause_isolates_on_exit',
@@ -47,7 +47,7 @@ Future<Map<String, dynamic>> runAndCollect(String scriptPath,
     coverage = await collect(serviceUri, true, true, includeDart, <String>{},
         timeout: timeout);
   } finally {
-    await process.stderr.drain<List<int>>();
+    await process.stderr.drain();
   }
   final exitStatus = await process.exitCode;
   if (exitStatus != 0) {

--- a/lib/src/util.dart
+++ b/lib/src/util.dart
@@ -8,10 +8,10 @@ import 'dart:io';
 /// Retries the specified function with the specified interval and returns
 /// the result on successful completion.
 Future<dynamic> retry(Future Function() f, Duration interval,
-    {Duration timeout}) async {
+    {Duration? timeout}) async {
   var keepGoing = true;
 
-  Future<dynamic> _withTimeout(Future Function() f, {Duration duration}) {
+  Future<dynamic> _withTimeout(Future Function() f, {Duration? duration}) {
     if (duration == null) {
       return f();
     }
@@ -41,7 +41,7 @@ Future<dynamic> retry(Future Function() f, Duration interval,
 /// Scrapes and returns the observatory URI from a string, or null if not found.
 ///
 /// Potentially useful as a means to extract it from log statements.
-Uri extractObservatoryUri(String str) {
+Uri? extractObservatoryUri(String str) {
   const kObservatoryListening = 'Observatory listening on ';
   final msgPos = str.indexOf(kObservatoryListening);
   if (msgPos == -1) return null;
@@ -135,7 +135,7 @@ const ignoreFile = '// coverage:ignore-file';
 /// ]
 /// ```
 ///
-List<List<int>> getIgnoredLines(List<String> lines) {
+List<List<int>> getIgnoredLines(List<String>? lines) {
   final ignoredLines = <List<int>>[];
   if (lines == null) return ignoredLines;
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -21,3 +21,7 @@ dev_dependencies:
 executables:
   collect_coverage:
   format_coverage:
+
+dependency_overrides:
+  test: ^1.16.0
+  test_core: ^0.3.14

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,24 +1,23 @@
 name: coverage
-version: 0.15.2
+version: 1.0.0
 description: Coverage data manipulation and formatting
 homepage: https://github.com/dart-lang/coverage
 
 environment:
-  sdk: '>=2.7.0 <3.0.0'
+  sdk: '>=2.12.0-0 <3.0.0'
 
 dependencies:
-  args: '>=1.4.0 <3.0.0'
-  logging: '>=0.9.0 <2.0.0'
-  package_config: '>=1.9.0 <3.0.0'
-  path: '>=0.9.0 <2.0.0'
-  source_maps: ^0.10.8
-  stack_trace: ^1.3.0
-  vm_service: '>=1.0.0 <7.0.0'
-
+  args: ^2.0.0
+  logging: ^1.0.0
+  package_config: ^2.0.0
+  path: ^1.8.0
+  source_maps: ^0.10.10
+  stack_trace: ^1.10.0
+  vm_service: ^6.1.0
 dev_dependencies:
-  pedantic: ^1.0.0
-  test: ^1.16.0-nullsafety.4
-  test_descriptor: ^2.0.0-nullsafety
+  pedantic: ^1.10.0
+  test: ^1.16.0
+  test_descriptor: ^2.0.0
 executables:
   collect_coverage:
   format_coverage:

--- a/test/chrome_test.dart
+++ b/test/chrome_test.dart
@@ -18,7 +18,7 @@ Future<String> sourceMapProvider(String scriptId) async {
   return File('test/test_files/main_test.js.map').readAsString();
 }
 
-Future<String> sourceProvider(String scriptId) async {
+Future<String?> sourceProvider(String scriptId) async {
   if (scriptId != mainScriptId) return null;
   return File('test/test_files/main_test.js').readAsString();
 }

--- a/test/collect_coverage_api_test.dart
+++ b/test/collect_coverage_api_test.dart
@@ -18,11 +18,6 @@ final _sampleAppFileUri = p.toUri(p.absolute(testAppPath)).toString();
 final _isolateLibFileUri = p.toUri(p.absolute(_isolateLibPath)).toString();
 
 void main() {
-  test('collect throws when serviceUri is null', () {
-    expect(() => collect(null, true, false, false, <String>{}),
-        throwsArgumentError);
-  });
-
   test('collect_coverage_api', () async {
     final json = await _collectCoverage();
     expect(json.keys, unorderedEquals(<String>['type', 'coverage']));
@@ -38,11 +33,11 @@ void main() {
       return map;
     });
 
-    for (var sampleCoverageData in sources[_sampleAppFileUri]) {
+    for (var sampleCoverageData in sources[_sampleAppFileUri]!) {
       expect(sampleCoverageData['hits'], isNotNull);
     }
 
-    for (var sampleCoverageData in sources[_isolateLibFileUri]) {
+    for (var sampleCoverageData in sources[_isolateLibFileUri]!) {
       expect(sampleCoverageData['hits'], isNotEmpty);
     }
   });
@@ -77,13 +72,13 @@ void main() {
     final coverage = json['coverage'] as List<Map<String, dynamic>>;
     expect(coverage, isNotEmpty);
 
-    final testAppCoverage = _getScriptCoverage(coverage, 'test_app.dart');
+    final testAppCoverage = _getScriptCoverage(coverage, 'test_app.dart')!;
     var hits = testAppCoverage['hits'] as List<int>;
     _expectHitCount(hits, 44, 0);
     _expectHitCount(hits, 48, 0);
 
     final isolateCoverage =
-        _getScriptCoverage(coverage, 'test_app_isolate.dart');
+        _getScriptCoverage(coverage, 'test_app_isolate.dart')!;
     hits = isolateCoverage['hits'] as List<int>;
     _expectHitCount(hits, 11, 1);
     _expectHitCount(hits, 18, 1);
@@ -91,8 +86,7 @@ void main() {
 }
 
 Future<Map<String, dynamic>> _collectCoverage(
-    {Set<String> scopedOutput, bool isolateIds = false}) async {
-  scopedOutput ??= <String>{};
+    {Set<String> scopedOutput = const {}, bool isolateIds = false}) async {
   final openPort = await getOpenPort();
 
   // run the sample app, with the right flags
@@ -126,7 +120,7 @@ Future<Map<String, dynamic>> _collectCoverage(
 
 // Returns the first coverage hitmap for the script with with the specified
 // script filename, ignoring leading path.
-Map<String, dynamic> _getScriptCoverage(
+Map<String, dynamic>? _getScriptCoverage(
     List<Map<String, dynamic>> coverage, String filename) {
   for (var isolateCoverage in coverage) {
     final script = Uri.parse(isolateCoverage['script']['uri'] as String);

--- a/test/collect_coverage_test.dart
+++ b/test/collect_coverage_test.dart
@@ -111,7 +111,7 @@ void main() {
   });
 }
 
-String _coverageData;
+String? _coverageData;
 
 Future<String> _getCoverageResult() async =>
     _coverageData ??= await _collectCoverage();
@@ -158,7 +158,7 @@ Future<String> _collectCoverage() async {
   }
 
   await sampleProcess.exitCode;
-  await sampleProcess.stderr.drain<List<int>>();
+  await sampleProcess.stderr.drain();
 
   return toolResult.stdout as String;
 }

--- a/test/format_coverage_test.dart
+++ b/test/format_coverage_test.dart
@@ -6,7 +6,7 @@ import 'package:test/test.dart';
 import '../bin/format_coverage.dart';
 
 void main() {
-  Directory testDir;
+  late Directory testDir;
   setUp(() {
     testDir = Directory.systemTemp.createTempSync('coverage_test_temp');
   });

--- a/test/lcov_test.dart
+++ b/test/lcov_test.dart
@@ -111,7 +111,7 @@ void main() {
       final hitLineRegexp = RegExp(r'\s+(\d+)\|  return a \+ b;');
       final match = hitLineRegexp.allMatches(res).single;
 
-      final hitCount = int.parse(match[1]);
+      final hitCount = int.parse(match[1]!);
       expect(hitCount, greaterThanOrEqualTo(1));
     });
 
@@ -186,6 +186,6 @@ Future<Map<String, Map<int, int>>> _getHitMap() async {
     throw ProcessException(
         'dart', sampleAppArgs, 'Fatal error. Exit code: $exitCode', exitCode);
   }
-  await sampleProcess.stderr.drain<List<int>>();
+  await sampleProcess.stderr.drain();
   return hitMap;
 }

--- a/test/test_files/test_app.dart
+++ b/test/test_files/test_app.dart
@@ -29,7 +29,7 @@ Future<Null> main() async {
   print('isolateId = $isolateID');
 
   isolate.addOnExitListener(port.sendPort);
-  isolate.resume(isolate.pauseCapability);
+  isolate.resume(isolate.pauseCapability!);
 
   final value = await port.first as int;
   if (value != 3) {


### PR DESCRIPTION
I did not do large refactors for the most part here I left in existing assumptions which means a lot of `!` are added.

Note that the `_shouldIgnoreLine` private method was moved to a local method and the patterns around it changed a fair bit due to iterators changing with null safety (it previously relied on `current` being null and now uses the result of `moveNext`).