### PR TITLE
allow null to be returned from the Chrome sourceUriProvider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.0.1 - 2021-02-25
+
+* Allow the chrome `sourceUriProvider` to return `null`.
+
 ## 1.0.0 - 2021-02-25
 
 * Migrate to null safety.

--- a/lib/src/chrome.dart
+++ b/lib/src/chrome.dart
@@ -15,7 +15,7 @@ import 'package:source_maps/parser.dart';
 /// scriptId, or null if not available.
 ///
 /// [sourceUriProvider] returns the uri for the provided sourceUrl and
-/// associated scriptId.
+/// associated scriptId, or null if not available.
 ///
 /// Chrome coverage information for which the corresponding source map or source
 /// content is null will be ignored.
@@ -23,7 +23,7 @@ Future<Map<String, dynamic>> parseChromeCoverage(
   List<Map<String, dynamic>> preciseCoverage,
   Future<String?> Function(String scriptId) sourceProvider,
   Future<String?> Function(String scriptId) sourceMapProvider,
-  Future<Uri> Function(String sourceUrl, String scriptId) sourceUriProvider,
+  Future<Uri?> Function(String sourceUrl, String scriptId) sourceUriProvider,
 ) async {
   final coverageReport = <Uri, Map<int, bool>>{};
   for (var entry in preciseCoverage) {
@@ -58,6 +58,7 @@ Future<Map<String, dynamic>> parseChromeCoverage(
         if (sourceUrl.startsWith('org-dartlang-sdk:')) continue;
 
         final uri = await sourceUriProvider(sourceUrl, scriptId);
+        if (uri == null) continue;
         final coverage = coverageReport.putIfAbsent(uri, () => <int, bool>{});
 
         final sourceLine = columnEntry.sourceLine!;

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: coverage
-version: 1.0.0
+version: 1.0.1
 description: Coverage data manipulation and formatting
 homepage: https://github.com/dart-lang/coverage
 


### PR DESCRIPTION
This was an incorrect migration originally it looks like, the test package returns null in a few different cases and it was previously handled a bit weirdly (adding entries with a null key). Now these are explicitly skipped.