### PR TITLE
Return a sorted hitmap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 1.0.4 - 2021-06-08
+
+* Ensure `createHitmap` returns a sorted hitmap. This fixes a potential issue with
+  ignore line annotations.
+
 ## 1.0.3 - 2021-05-25
 
 * Updated dependency on `vm_service` package from `^6.1.0` to `>=6.1.0 <8.0.0`.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: coverage
-version: 1.0.3
+version: 1.0.4
 description: Coverage data manipulation and formatting
 homepage: https://github.com/dart-lang/coverage
 

--- a/test/collect_coverage_test.dart
+++ b/test/collect_coverage_test.dart
@@ -49,6 +49,37 @@ void main() {
     }
   });
 
+  test('createHitmap returns a sorted hitmap', () async {
+    final coverage = [
+      {
+        'source': 'foo',
+        'script': '{type: @Script, fixedId: true, '
+            'id: bar.dart, uri: bar.dart, _kind: library}',
+        'hits': [
+          45,
+          1,
+          46,
+          1,
+          49,
+          0,
+          50,
+          0,
+          15,
+          1,
+          16,
+          2,
+          17,
+          2,
+        ]
+      }
+    ];
+    final hitMap = await createHitmap(
+      coverage.cast<Map<String, dynamic>>(),
+    );
+    final expectedHits = {15: 1, 16: 2, 17: 2, 45: 1, 46: 1, 49: 0, 50: 0};
+    expect(hitMap['foo'], expectedHits);
+  });
+
   test('createHitmap', () async {
     final resultString = await _getCoverageResult();
     final jsonResult = json.decode(resultString) as Map<String, dynamic>;


### PR DESCRIPTION
Update `createHitmap` to return a sorted hitmap which is required by the ignore line annotations.