### PR TITLE
Use the report lines flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,3 @@
-## 1.1.1-dev
-
-* Use the `reportLines` flag in `vm_service`'s `getSourceReport` RPC. This
-  typiclly halves the number of RPCs that the coverage collector needs to run.
-
 ## 1.1.0-dev
 
 * Support function level coverage information, when running tests in the Dart
@@ -21,6 +16,8 @@
   optional bool flag controlling whether function coverage is collected.
 * Ensure `createHitmap` returns a sorted hitmap. This fixes a potential issue with
   ignore line annotations.
+* Use the `reportLines` flag in `vm_service`'s `getSourceReport` RPC. This
+  typiclly halves the number of RPCs that the coverage collector needs to run.
 
 ## 1.0.3 - 2021-05-25
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@
 * Ensure `createHitmap` returns a sorted hitmap. This fixes a potential issue with
   ignore line annotations.
 * Use the `reportLines` flag in `vm_service`'s `getSourceReport` RPC. This
-  typiclly halves the number of RPCs that the coverage collector needs to run.
+  typically halves the number of RPCs that the coverage collector needs to run.
 
 ## 1.0.3 - 2021-05-25
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 1.1.1-dev
+
+* Use the `reportLines` flag in `vm_service`'s `getSourceReport` RPC. This
+  typiclly halves the number of RPCs that the coverage collector needs to run.
+
 ## 1.1.0-dev
 
 * Support function level coverage information, when running tests in the Dart

--- a/lib/src/collect.dart
+++ b/lib/src/collect.dart
@@ -97,8 +97,10 @@ Future<Map<String, dynamic>> _getAllCoverage(
   scopedOutput ??= <String>{};
   final vm = await service.getVM();
   final allCoverage = <Map<String, dynamic>>[];
-  final ver = await service.getVersion();
-  final reportLines = ver.major == 3 && ver.minor != null && ver.minor! >= 51;
+  final version = await service.getVersion();
+  final reportLines =
+      (version.major == 3 && version.minor != null && version.minor! >= 51) ||
+          (version.major != null && version.major! > 3);
 
   for (var isolateRef in vm.isolates!) {
     if (isolateIds != null && !isolateIds.contains(isolateRef.id)) continue;

--- a/lib/src/collect.dart
+++ b/lib/src/collect.dart
@@ -97,6 +97,8 @@ Future<Map<String, dynamic>> _getAllCoverage(
   scopedOutput ??= <String>{};
   final vm = await service.getVM();
   final allCoverage = <Map<String, dynamic>>[];
+  final ver = await service.getVersion();
+  final reportLines = ver.major == 3 && ver.minor != null && ver.minor! >= 51;
 
   for (var isolateRef in vm.isolates!) {
     if (isolateIds != null && !isolateIds.contains(isolateRef.id)) continue;
@@ -110,9 +112,11 @@ Future<Map<String, dynamic>> _getAllCoverage(
         if (!scopedOutput.contains(scope)) continue;
         final scriptReport = await service.getSourceReport(
             isolateRef.id!, <String>[SourceReportKind.kCoverage],
-            forceCompile: true, scriptId: script.id);
-        final coverage = await _getCoverageJson(
-            service, isolateRef, scriptReport, includeDart, functionCoverage);
+            forceCompile: true,
+            scriptId: script.id,
+            reportLines: reportLines ? true : null);
+        final coverage = await _getCoverageJson(service, isolateRef,
+            scriptReport, includeDart, functionCoverage, reportLines);
         allCoverage.addAll(coverage);
       }
     } else {
@@ -120,9 +124,10 @@ Future<Map<String, dynamic>> _getAllCoverage(
         isolateRef.id!,
         <String>[SourceReportKind.kCoverage],
         forceCompile: true,
+        reportLines: reportLines ? true : null,
       );
-      final coverage = await _getCoverageJson(
-          service, isolateRef, isolateReport, includeDart, functionCoverage);
+      final coverage = await _getCoverageJson(service, isolateRef,
+          isolateReport, includeDart, functionCoverage, reportLines);
       allCoverage.addAll(coverage);
     }
   }
@@ -220,10 +225,12 @@ Future<List<Map<String, dynamic>>> _getCoverageJson(
     IsolateRef isolateRef,
     SourceReport report,
     bool includeDart,
-    bool functionCoverage) async {
+    bool functionCoverage,
+    bool reportLines) async {
   final hitMaps = <Uri, HitMap>{};
   final scripts = <ScriptRef, Script>{};
   final libraries = <LibraryRef>{};
+  final needScripts = functionCoverage || !reportLines;
   for (var range in report.ranges!) {
     final scriptRef = report.scripts![range.scriptIndex!];
     final scriptUri = Uri.parse(report.scripts![range.scriptIndex!].uri!);
@@ -234,18 +241,22 @@ Future<List<Map<String, dynamic>>> _getCoverageJson(
     // Skip scripts from dart:.
     if (!includeDart && scriptUri.scheme == 'dart') continue;
 
-    if (!scripts.containsKey(scriptRef)) {
-      scripts[scriptRef] =
-          await service.getObject(isolateRef.id!, scriptRef.id!) as Script;
-    }
-    final script = scripts[scriptRef];
-    if (script == null) continue;
-
     // Look up the hit maps for this script (shared across isolates).
     final hits = hitMaps.putIfAbsent(scriptUri, () => HitMap());
 
+    Script? script;
+    if (needScripts) {
+      if (!scripts.containsKey(scriptRef)) {
+        scripts[scriptRef] =
+            await service.getObject(isolateRef.id!, scriptRef.id!) as Script;
+      }
+      script = scripts[scriptRef];
+
+      if (script == null) continue;
+    }
+
     // If the script's library isn't loaded, load it then look up all its funcs.
-    final libRef = script.library;
+    final libRef = script?.library;
     if (functionCoverage && libRef != null && !libraries.contains(libRef)) {
       hits.funcHits ??= <int, int>{};
       hits.funcNames ??= <int, String>{};
@@ -254,7 +265,7 @@ Future<List<Map<String, dynamic>>> _getCoverageJson(
           await service.getObject(isolateRef.id!, libRef.id!) as Library;
       if (library.functions != null) {
         for (var funcRef in library.functions!) {
-          await _processFunction(service, isolateRef, script, funcRef, hits);
+          await _processFunction(service, isolateRef, script!, funcRef, hits);
         }
       }
       if (library.classes != null) {
@@ -264,7 +275,7 @@ Future<List<Map<String, dynamic>>> _getCoverageJson(
           if (clazz.functions != null) {
             for (var funcRef in clazz.functions!) {
               await _processFunction(
-                  service, isolateRef, script, funcRef, hits);
+                  service, isolateRef, script!, funcRef, hits);
             }
           }
         }
@@ -276,10 +287,10 @@ Future<List<Map<String, dynamic>>> _getCoverageJson(
 
     if (coverage == null) continue;
 
-    for (final tokenPos in coverage.hits!) {
-      final line = _getLineFromTokenPos(script, tokenPos);
+    for (final pos in coverage.hits!) {
+      final line = reportLines ? pos : _getLineFromTokenPos(script!, pos);
       if (line == null) {
-        print('tokenPos $tokenPos has no line mapping for script $scriptUri');
+        print('tokenPos $pos has no line mapping for script $scriptUri');
         continue;
       }
       _incrementCountForKey(hits.lineHits, line);
@@ -287,10 +298,10 @@ Future<List<Map<String, dynamic>>> _getCoverageJson(
         _incrementCountForKey(hits.funcHits!, line);
       }
     }
-    for (final tokenPos in coverage.misses!) {
-      final line = _getLineFromTokenPos(script, tokenPos);
+    for (final pos in coverage.misses!) {
+      final line = reportLines ? pos : _getLineFromTokenPos(script!, pos);
       if (line == null) {
-        print('tokenPos $tokenPos has no line mapping for script $scriptUri');
+        print('tokenPos $pos has no line mapping for script $scriptUri');
         continue;
       }
       hits.lineHits.putIfAbsent(line, () => 0);

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: coverage
-version: 1.1.1-dev
+version: 1.1.0-dev
 description: Coverage data manipulation and formatting
 homepage: https://github.com/dart-lang/coverage
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -13,7 +13,7 @@ dependencies:
   path: ^1.8.0
   source_maps: ^0.10.10
   stack_trace: ^1.10.0
-  vm_service: ">=6.1.0 <8.0.0"
+  vm_service: ">=7.3.0 <8.0.0"
 dev_dependencies:
   pedantic: ^1.10.0
   test: ^1.16.0

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: coverage
-version: 1.1.0-dev
+version: 1.1.1-dev
 description: Coverage data manipulation and formatting
 homepage: https://github.com/dart-lang/coverage
 

--- a/test/collect_coverage_api_test.dart
+++ b/test/collect_coverage_api_test.dart
@@ -34,7 +34,7 @@ void main() {
     });
 
     for (var sampleCoverageData in sources[_sampleAppFileUri]!) {
-      expect(sampleCoverageData['hits'], isNotNull);
+      expect(sampleCoverageData['hits'], isNotEmpty);
     }
 
     for (var sampleCoverageData in sources[_isolateLibFileUri]!) {
@@ -100,8 +100,8 @@ void main() {
     });
 
     for (var sampleCoverageData in sources[_sampleAppFileUri]!) {
-      expect(sampleCoverageData['funcNames'], isNotNull);
-      expect(sampleCoverageData['funcHits'], isNotNull);
+      expect(sampleCoverageData['funcNames'], isNotEmpty);
+      expect(sampleCoverageData['funcHits'], isNotEmpty);
     }
 
     for (var sampleCoverageData in sources[_isolateLibFileUri]!) {

--- a/test/collect_coverage_test.dart
+++ b/test/collect_coverage_test.dart
@@ -81,7 +81,7 @@ void main() {
   });
 
   test('createHitmap', () async {
-    final resultString = await _getCoverageResult();
+    final resultString = await _collectCoverage(true);
     final jsonResult = json.decode(resultString) as Map<String, dynamic>;
     final coverage = jsonResult['coverage'] as List;
     final hitMap = await createHitmap(
@@ -191,9 +191,9 @@ void main() {
 String? _coverageData;
 
 Future<String> _getCoverageResult() async =>
-    _coverageData ??= await _collectCoverage();
+    _coverageData ??= await _collectCoverage(false);
 
-Future<String> _collectCoverage() async {
+Future<String> _collectCoverage(bool functionCoverage) async {
   expect(FileSystemEntity.isFileSync(testAppPath), isTrue);
 
   final openPort = await getOpenPort();
@@ -220,7 +220,7 @@ Future<String> _collectCoverage() async {
   // TODO: need to get all of this functionality in the lib
   final toolResult = await Process.run('dart', [
     _collectAppPath,
-    '--function-coverage',
+    if (functionCoverage) '--function-coverage',
     '--uri',
     '$serviceUri',
     '--resume-isolates',


### PR DESCRIPTION
The report lines flag returns the line numbers directly in the source report, rather than the token positions. This lets us skip the extra RPC to get the token pos to line number mapping. In my benchmarks, this halved the time it takes to collect coverage.

We still have to get the script objects if function coverage was requested. So to make sure the RPC skipping flow is tested, I've updated some of the tests so that function coverage is tested separately.