### PR TITLE
Gather coverage once per isolate group

### DIFF
--- a/lib/src/collect.dart
+++ b/lib/src/collect.dart
@@ -102,8 +102,25 @@ Future<Map<String, dynamic>> _getAllCoverage(
       (version.major == 3 && version.minor != null && version.minor! >= 51) ||
           (version.major != null && version.major! > 3);
 
+  // Program counters are shared between isolates in the same group. So we need
+  // to make sure we're only gathering coverage data for one isolate in each
+  // group, otherwise we'll double count the hits.
+  final isolateOwnerGroup = <String, String>{};
+  final coveredIsolateGroups = <String>{};
+  for (var isolateGroupRef in vm.isolateGroups!) {
+    final isolateGroup = await service.getIsolateGroup(isolateGroupRef.id!);
+    for (var isolateRef in isolateGroup.isolates!) {
+      isolateOwnerGroup[isolateRef.id!] = isolateGroupRef.id!;
+    }
+  }
+
   for (var isolateRef in vm.isolates!) {
     if (isolateIds != null && !isolateIds.contains(isolateRef.id)) continue;
+    final isolateGroupId = isolateOwnerGroup[isolateRef.id];
+    if (isolateGroupId != null) {
+      if (coveredIsolateGroups.contains(isolateGroupId)) continue;
+      coveredIsolateGroups.add(isolateGroupId);
+    }
     if (scopedOutput.isNotEmpty) {
       final scripts = await service.getScripts(isolateRef.id!);
       for (var script in scripts.scripts!) {

--- a/test/collect_coverage_api_test.dart
+++ b/test/collect_coverage_api_test.dart
@@ -131,28 +131,3 @@ Future<Map<String, dynamic>> _collectCoverage(
       isolateIds: isolateIdSet,
       functionCoverage: functionCoverage);
 }
-
-// Returns the first coverage hitmap for the script with with the specified
-// script filename, ignoring leading path.
-Map<String, dynamic>? _getScriptCoverage(
-    List<Map<String, dynamic>> coverage, String filename) {
-  for (var isolateCoverage in coverage) {
-    final script = Uri.parse(isolateCoverage['script']['uri'] as String);
-    if (script.pathSegments.last == filename) {
-      return isolateCoverage;
-    }
-  }
-  return null;
-}
-
-/// Tests that the specified hitmap has the specified hit count for the
-/// specified line.
-void _expectHitCount(List<int> hits, int line, int hitCount) {
-  final hitIndex = hits.indexOf(line);
-  if (hitIndex < 0) {
-    fail('No hit count for line $line');
-  }
-  final actual = hits[hitIndex + 1];
-  expect(actual, equals(hitCount),
-      reason: 'Expected line $line to have $hitCount hits, but found $actual.');
-}

--- a/test/collect_coverage_api_test.dart
+++ b/test/collect_coverage_api_test.dart
@@ -70,18 +70,7 @@ void main() {
     expect(json, containsPair('type', 'CodeCoverage'));
 
     final coverage = json['coverage'] as List<Map<String, dynamic>>;
-    expect(coverage, isNotEmpty);
-
-    final testAppCoverage = _getScriptCoverage(coverage, 'test_app.dart')!;
-    var hits = testAppCoverage['hits'] as List<int>;
-    _expectHitCount(hits, 46, 0);
-    _expectHitCount(hits, 50, 0);
-
-    final isolateCoverage =
-        _getScriptCoverage(coverage, 'test_app_isolate.dart')!;
-    hits = isolateCoverage['hits'] as List<int>;
-    _expectHitCount(hits, 11, 1);
-    _expectHitCount(hits, 28, 1);
+    expect(coverage, isEmpty);
   });
 
   test('collect_coverage_api with function coverage', () async {
@@ -122,7 +111,6 @@ Future<Map<String, dynamic>> _collectCoverage(
 
   // Capture the VM service URI.
   final serviceUriCompleter = Completer<Uri>();
-  final isolateIdCompleter = Completer<String>();
   sampleProcess.stdout
       .transform(utf8.decoder)
       .transform(LineSplitter())
@@ -133,14 +121,10 @@ Future<Map<String, dynamic>> _collectCoverage(
         serviceUriCompleter.complete(serviceUri);
       }
     }
-    if (line.contains('isolateId = ')) {
-      isolateIdCompleter.complete(line.split(' = ')[1]);
-    }
   });
 
   final serviceUri = await serviceUriCompleter.future;
-  final isolateId = await isolateIdCompleter.future;
-  final isolateIdSet = isolateIds ? {isolateId} : null;
+  final isolateIdSet = isolateIds ? <String>{} : null;
 
   return collect(serviceUri, true, true, false, scopedOutput,
       timeout: timeout,


### PR DESCRIPTION
Isolate groups were enabled by default in the Dart VM recently. The hit counters are shared between all isolates in the group, so this caused a regression where coverage hits were being double counted. This PR fixes that regression by only collecting coverage for the first isolate in each group. This should also give us a significant performance boost in multi-isolate programs.