### PR TITLE
Change function coverage to be backwards compatible

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,12 +11,12 @@
   coverage, in addition to line level.
 * Add an optional bool flag to `collect` that controls whether function coverage
   is collected.
-* Added `createHitmapV2`, `mergeHitmapsV2`, `parseCoverageV2`,
-  `toScriptCoverageJsonV2`, and `Formatter.formatV2` that switch from using
+* Added `HitMap.parseJson`, `FileHitMaps.merge`, `HitMap.parseFiles`,
+  `HitMap.toJson`, and `Formatter.formatV2` that switch from using
   `Map<int, int>` to represent line coverage to using `HitMap` (which contains
-  both line and function coverage). Document the old versions as deprecated. We
-  will depete the old functions and remove the "V2" from the new ones when we
-  update to coverage version 2.0.0.
+  both line and function coverage). Document the old versions of these functions
+  as deprecated. We will delete the old functions when we update to coverage
+  version 2.0.0.
 * Ensure `createHitmap` returns a sorted hitmap. This fixes a potential issue with
   ignore line annotations.
 * Use the `reportLines` flag in `vm_service`'s `getSourceReport` RPC. This

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,10 +12,11 @@
 * Add an optional bool flag to `collect` that controls whether function coverage
   is collected.
 * Added `HitMap.parseJson`, `FileHitMaps.merge`, `HitMap.parseFiles`,
-  `HitMap.toJson`, and `Formatter.formatV2` that switch from using
-  `Map<int, int>` to represent line coverage to using `HitMap` (which contains
-  both line and function coverage). Document the old versions of these functions
-  as deprecated. We will delete the old functions when we update to coverage
+  `HitMap.toJson`, `FileHitMapsFormatter.formatLcov`, and
+  `FileHitMapsFormatter.prettyPrint` that switch from using `Map<int, int>` to
+  represent line coverage to using `HitMap` (which contains both line and
+  function coverage). Document the old versions of these functions as
+  deprecated. We will delete the old functions when we update to coverage
   version 2.0.0.
 * Ensure `createHitmap` returns a sorted hitmap. This fixes a potential issue with
   ignore line annotations.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,11 +9,14 @@
   line level.
 * Update `--lcov` (abbr `-l`) in format_coverage to output function level
   coverage, in addition to line level.
-* BREAKING CHANGE: The signatures of `createHitmap`, `mergeHitmaps`,
-  `parseCoverage`, `toScriptCoverageJson`, and `Formatter.format` have changed
-  from using `Map<int, int>` to represent line coverage to using `HitMap`
-  (which contains both line and function coverage). `collect` also has a new
-  optional bool flag controlling whether function coverage is collected.
+* Add an optional bool flag to `collect` that controls whether function coverage
+  is collected.
+* Added `createHitmapV2`, `mergeHitmapsV2`, `parseCoverageV2`,
+  `toScriptCoverageJsonV2`, and `Formatter.formatV2` that switch from using
+  `Map<int, int>` to represent line coverage to using `HitMap` (which contains
+  both line and function coverage). Document the old versions as deprecated. We
+  will depete the old functions and remove the "V2" from the new ones when we
+  update to coverage version 2.0.0.
 * Ensure `createHitmap` returns a sorted hitmap. This fixes a potential issue with
   ignore line annotations.
 * Use the `reportLines` flag in `vm_service`'s `getSourceReport` RPC. This

--- a/bin/format_coverage.dart
+++ b/bin/format_coverage.dart
@@ -58,9 +58,8 @@ Future<void> main(List<String> arguments) async {
   }
 
   final clock = Stopwatch()..start();
-  final hitmap = await parseCoverageV2(
+  final hitmap = await HitMap.parseFiles(
     files,
-    env.workers,
     checkIgnoredLines: env.checkIgnore,
     packagesPath: env.packagesPath,
   );

--- a/bin/format_coverage.dart
+++ b/bin/format_coverage.dart
@@ -75,14 +75,12 @@ Future<void> main(List<String> arguments) async {
       : Resolver(packagesPath: env.packagesPath, sdkRoot: env.sdkRoot);
   final loader = Loader();
   if (env.prettyPrint || env.prettyPrintFunc) {
-    output = await PrettyPrintFormatter(resolver, loader,
-            reportOn: env.reportOn, reportFuncs: env.prettyPrintFunc)
-        .formatV2(hitmap);
+    output = await hitmap.prettyPrint(resolver, loader,
+        reportOn: env.reportOn, reportFuncs: env.prettyPrintFunc);
   } else {
     assert(env.lcov);
-    output = await LcovFormatter(resolver,
-            reportOn: env.reportOn, basePath: env.baseDirectory)
-        .formatV2(hitmap);
+    output = hitmap.formatLcov(resolver,
+        reportOn: env.reportOn, basePath: env.baseDirectory);
   }
 
   env.output.write(output);

--- a/bin/format_coverage.dart
+++ b/bin/format_coverage.dart
@@ -58,7 +58,7 @@ Future<void> main(List<String> arguments) async {
   }
 
   final clock = Stopwatch()..start();
-  final hitmap = await parseCoverage(
+  final hitmap = await parseCoverageV2(
     files,
     env.workers,
     checkIgnoredLines: env.checkIgnore,
@@ -78,12 +78,12 @@ Future<void> main(List<String> arguments) async {
   if (env.prettyPrint || env.prettyPrintFunc) {
     output = await PrettyPrintFormatter(resolver, loader,
             reportOn: env.reportOn, reportFuncs: env.prettyPrintFunc)
-        .format(hitmap);
+        .formatV2(hitmap);
   } else {
     assert(env.lcov);
     output = await LcovFormatter(resolver,
             reportOn: env.reportOn, basePath: env.baseDirectory)
-        .format(hitmap);
+        .formatV2(hitmap);
   }
 
   env.output.write(output);

--- a/lib/coverage.dart
+++ b/lib/coverage.dart
@@ -5,6 +5,6 @@
 export 'src/chrome.dart';
 export 'src/collect.dart';
 export 'src/formatter.dart';
-export 'src/hitmap.dart';
+export 'src/hitmap.dart' hide hitmapToJson;
 export 'src/resolver.dart';
 export 'src/run_and_collect.dart';

--- a/lib/src/chrome.dart
+++ b/lib/src/chrome.dart
@@ -81,7 +81,7 @@ Future<Map<String, dynamic>> parseChromeCoverage(
 
   final allCoverage = <Map<String, dynamic>>[];
   coverageHitMaps.forEach((uri, hitMap) {
-    allCoverage.add(hitMap.toJson(uri));
+    allCoverage.add(hitmapToJson(hitMap, uri));
   });
   return <String, dynamic>{'type': 'CodeCoverage', 'coverage': allCoverage};
 }

--- a/lib/src/chrome.dart
+++ b/lib/src/chrome.dart
@@ -81,7 +81,7 @@ Future<Map<String, dynamic>> parseChromeCoverage(
 
   final allCoverage = <Map<String, dynamic>>[];
   coverageHitMaps.forEach((uri, hitMap) {
-    allCoverage.add(toScriptCoverageJsonV2(uri, hitMap));
+    allCoverage.add(hitMap.toJson(uri));
   });
   return <String, dynamic>{'type': 'CodeCoverage', 'coverage': allCoverage};
 }

--- a/lib/src/chrome.dart
+++ b/lib/src/chrome.dart
@@ -81,7 +81,7 @@ Future<Map<String, dynamic>> parseChromeCoverage(
 
   final allCoverage = <Map<String, dynamic>>[];
   coverageHitMaps.forEach((uri, hitMap) {
-    allCoverage.add(toScriptCoverageJson(uri, hitMap));
+    allCoverage.add(toScriptCoverageJsonV2(uri, hitMap));
   });
   return <String, dynamic>{'type': 'CodeCoverage', 'coverage': allCoverage};
 }

--- a/lib/src/collect.dart
+++ b/lib/src/collect.dart
@@ -333,7 +333,7 @@ Future<List<Map<String, dynamic>>> _getCoverageJson(
   // Output JSON
   final coverage = <Map<String, dynamic>>[];
   hitMaps.forEach((uri, hits) {
-    coverage.add(toScriptCoverageJsonV2(uri, hits));
+    coverage.add(hits.toJson(uri));
   });
   return coverage;
 }

--- a/lib/src/collect.dart
+++ b/lib/src/collect.dart
@@ -333,7 +333,7 @@ Future<List<Map<String, dynamic>>> _getCoverageJson(
   // Output JSON
   final coverage = <Map<String, dynamic>>[];
   hitMaps.forEach((uri, hits) {
-    coverage.add(toScriptCoverageJson(uri, hits));
+    coverage.add(toScriptCoverageJsonV2(uri, hits));
   });
   return coverage;
 }

--- a/lib/src/collect.dart
+++ b/lib/src/collect.dart
@@ -333,7 +333,7 @@ Future<List<Map<String, dynamic>>> _getCoverageJson(
   // Output JSON
   final coverage = <Map<String, dynamic>>[];
   hitMaps.forEach((uri, hits) {
-    coverage.add(hits.toJson(uri));
+    coverage.add(hitmapToJson(hits, uri));
   });
   return coverage;
 }

--- a/lib/src/formatter.dart
+++ b/lib/src/formatter.dart
@@ -9,11 +9,8 @@ import 'hitmap.dart';
 
 abstract class Formatter {
   /// Returns the formatted coverage data.
-  @Deprecated('Migrate to formatV2')
+  @Deprecated('Migrate to FileHitMapsFormatter')
   Future<String> format(Map<String, Map<int, int>> hitmap);
-
-  /// Returns the formatted coverage data.
-  Future<String> formatV2(Map<String, HitMap> hitmap);
 }
 
 /// Converts the given hitmap to lcov format and appends the result to
@@ -33,56 +30,12 @@ class LcovFormatter implements Formatter {
   final String? basePath;
   final List<String>? reportOn;
 
-  @Deprecated('Migrate to formatV2')
+  @Deprecated('Migrate to FileHitMapsFormatter.formatLcov')
   @override
   Future<String> format(Map<String, Map<int, int>> hitmap) {
-    return formatV2(hitmap.map((key, value) => MapEntry(key, HitMap(value))));
-  }
-
-  @override
-  Future<String> formatV2(Map<String, HitMap> hitmap) async {
-    final pathFilter = _getPathFilter(reportOn);
-    final buf = StringBuffer();
-    for (var key in hitmap.keys) {
-      final v = hitmap[key]!;
-      final lineHits = v.lineHits;
-      final funcHits = v.funcHits;
-      final funcNames = v.funcNames;
-      var source = resolver.resolve(key);
-      if (source == null) {
-        continue;
-      }
-
-      if (!pathFilter(source)) {
-        continue;
-      }
-
-      if (basePath != null) {
-        source = p.relative(source, from: basePath);
-      }
-
-      buf.write('SF:$source\n');
-      if (funcHits != null && funcNames != null) {
-        for (var k in funcNames.keys.toList()..sort()) {
-          buf.write('FN:$k,${funcNames[k]}\n');
-        }
-        for (var k in funcHits.keys.toList()..sort()) {
-          if (funcHits[k]! != 0) {
-            buf.write('FNDA:${funcHits[k]},${funcNames[k]}\n');
-          }
-        }
-        buf.write('FNF:${funcNames.length}\n');
-        buf.write('FNH:${funcHits.values.where((v) => v > 0).length}\n');
-      }
-      for (var k in lineHits.keys.toList()..sort()) {
-        buf.write('DA:$k,${lineHits[k]}\n');
-      }
-      buf.write('LF:${lineHits.length}\n');
-      buf.write('LH:${lineHits.values.where((v) => v > 0).length}\n');
-      buf.write('end_of_record\n');
-    }
-
-    return buf.toString();
+    return Future.value(hitmap
+        .map((key, value) => MapEntry(key, HitMap(value)))
+        .formatLcov(resolver, basePath: basePath, reportOn: reportOn));
   }
 }
 
@@ -104,25 +57,91 @@ class PrettyPrintFormatter implements Formatter {
   final List<String>? reportOn;
   final bool reportFuncs;
 
-  @Deprecated('Migrate to formatV2')
+  @Deprecated('Migrate to FileHitMapsFormatter.prettyPrint')
   @override
   Future<String> format(Map<String, Map<int, int>> hitmap) {
-    return formatV2(hitmap.map((key, value) => MapEntry(key, HitMap(value))));
+    return hitmap.map((key, value) => MapEntry(key, HitMap(value))).prettyPrint(
+        resolver, loader,
+        reportOn: reportOn, reportFuncs: reportFuncs);
   }
+}
 
-  @override
-  Future<String> formatV2(Map<String, HitMap> hitmap) async {
+extension FileHitMapsFormatter on Map<String, HitMap> {
+  /// Converts the given hitmap to lcov format.
+  ///
+  /// If [reportOn] is provided, coverage report output is limited to files
+  /// prefixed with one of the paths included. If [basePath] is provided, paths
+  /// are reported relative to that path.
+  String formatLcov(
+    Resolver resolver, {
+    String? basePath,
+    List<String>? reportOn,
+  }) {
     final pathFilter = _getPathFilter(reportOn);
     final buf = StringBuffer();
-    for (var key in hitmap.keys) {
-      final v = hitmap[key]!;
+    for (final entry in entries) {
+      final v = entry.value;
+      final lineHits = v.lineHits;
+      final funcHits = v.funcHits;
+      final funcNames = v.funcNames;
+      var source = resolver.resolve(entry.key);
+      if (source == null) {
+        continue;
+      }
+
+      if (!pathFilter(source)) {
+        continue;
+      }
+
+      if (basePath != null) {
+        source = p.relative(source, from: basePath);
+      }
+
+      buf.write('SF:$source\n');
+      if (funcHits != null && funcNames != null) {
+        for (final k in funcNames.keys.toList()..sort()) {
+          buf.write('FN:$k,${funcNames[k]}\n');
+        }
+        for (final k in funcHits.keys.toList()..sort()) {
+          if (funcHits[k]! != 0) {
+            buf.write('FNDA:${funcHits[k]},${funcNames[k]}\n');
+          }
+        }
+        buf.write('FNF:${funcNames.length}\n');
+        buf.write('FNH:${funcHits.values.where((v) => v > 0).length}\n');
+      }
+      for (final k in lineHits.keys.toList()..sort()) {
+        buf.write('DA:$k,${lineHits[k]}\n');
+      }
+      buf.write('LF:${lineHits.length}\n');
+      buf.write('LH:${lineHits.values.where((v) => v > 0).length}\n');
+      buf.write('end_of_record\n');
+    }
+
+    return buf.toString();
+  }
+
+  /// Converts the given hitmap to a pretty-print format.
+  ///
+  /// If [reportOn] is provided, coverage report output is limited to files
+  /// prefixed with one of the paths included.
+  Future<String> prettyPrint(
+    Resolver resolver,
+    Loader loader, {
+    List<String>? reportOn,
+    bool reportFuncs = false,
+  }) async {
+    final pathFilter = _getPathFilter(reportOn);
+    final buf = StringBuffer();
+    for (final entry in entries) {
+      final v = entry.value;
       if (reportFuncs && v.funcHits == null) {
         throw 'Function coverage formatting was requested, but the hit map is '
             'missing function coverage information. Did you run '
             'collect_coverage with the --function-coverage flag?';
       }
       final hits = reportFuncs ? v.funcHits! : v.lineHits;
-      final source = resolver.resolve(key);
+      final source = resolver.resolve(entry.key);
       if (source == null) {
         continue;
       }

--- a/lib/src/formatter.dart
+++ b/lib/src/formatter.dart
@@ -9,7 +9,12 @@ import 'hitmap.dart';
 
 abstract class Formatter {
   /// Returns the formatted coverage data.
-  Future<String> format(Map<String, HitMap> hitmap);
+  ///
+  /// [DEPRECATED] Migrate to formatV2.
+  Future<String> format(Map<String, Map<int, int>> hitmap);
+
+  /// Returns the formatted coverage data.
+  Future<String> formatV2(Map<String, HitMap> hitmap);
 }
 
 /// Converts the given hitmap to lcov format and appends the result to
@@ -30,7 +35,12 @@ class LcovFormatter implements Formatter {
   final List<String>? reportOn;
 
   @override
-  Future<String> format(Map<String, HitMap> hitmap) async {
+  Future<String> format(Map<String, Map<int, int>> hitmap) {
+    return formatV2(hitmap.map((key, value) => MapEntry(key, HitMap(value))));
+  }
+
+  @override
+  Future<String> formatV2(Map<String, HitMap> hitmap) async {
     final pathFilter = _getPathFilter(reportOn);
     final buf = StringBuffer();
     for (var key in hitmap.keys) {
@@ -95,7 +105,12 @@ class PrettyPrintFormatter implements Formatter {
   final bool reportFuncs;
 
   @override
-  Future<String> format(Map<String, HitMap> hitmap) async {
+  Future<String> format(Map<String, Map<int, int>> hitmap) {
+    return formatV2(hitmap.map((key, value) => MapEntry(key, HitMap(value))));
+  }
+
+  @override
+  Future<String> formatV2(Map<String, HitMap> hitmap) async {
     final pathFilter = _getPathFilter(reportOn);
     final buf = StringBuffer();
     for (var key in hitmap.keys) {

--- a/lib/src/formatter.dart
+++ b/lib/src/formatter.dart
@@ -33,6 +33,7 @@ class LcovFormatter implements Formatter {
   final String? basePath;
   final List<String>? reportOn;
 
+  @Deprecated('Migrate to formatV2')
   @override
   Future<String> format(Map<String, Map<int, int>> hitmap) {
     return formatV2(hitmap.map((key, value) => MapEntry(key, HitMap(value))));
@@ -103,6 +104,7 @@ class PrettyPrintFormatter implements Formatter {
   final List<String>? reportOn;
   final bool reportFuncs;
 
+  @Deprecated('Migrate to formatV2')
   @override
   Future<String> format(Map<String, Map<int, int>> hitmap) {
     return formatV2(hitmap.map((key, value) => MapEntry(key, HitMap(value))));

--- a/lib/src/formatter.dart
+++ b/lib/src/formatter.dart
@@ -7,9 +7,9 @@ import 'package:path/path.dart' as p;
 import 'resolver.dart';
 import 'hitmap.dart';
 
+@Deprecated('Migrate to FileHitMapsFormatter')
 abstract class Formatter {
   /// Returns the formatted coverage data.
-  @Deprecated('Migrate to FileHitMapsFormatter')
   Future<String> format(Map<String, Map<int, int>> hitmap);
 }
 
@@ -18,6 +18,7 @@ abstract class Formatter {
 ///
 /// Returns a [Future] that completes as soon as all map entries have been
 /// emitted.
+@Deprecated('Migrate to FileHitMapsFormatter.formatLcov')
 class LcovFormatter implements Formatter {
   /// Creates a LCOV formatter.
   ///
@@ -30,7 +31,6 @@ class LcovFormatter implements Formatter {
   final String? basePath;
   final List<String>? reportOn;
 
-  @Deprecated('Migrate to FileHitMapsFormatter.formatLcov')
   @override
   Future<String> format(Map<String, Map<int, int>> hitmap) {
     return Future.value(hitmap
@@ -44,6 +44,7 @@ class LcovFormatter implements Formatter {
 ///
 /// Returns a [Future] that completes as soon as all map entries have been
 /// emitted.
+@Deprecated('Migrate to FileHitMapsFormatter.prettyPrint')
 class PrettyPrintFormatter implements Formatter {
   /// Creates a pretty-print formatter.
   ///
@@ -57,7 +58,6 @@ class PrettyPrintFormatter implements Formatter {
   final List<String>? reportOn;
   final bool reportFuncs;
 
-  @Deprecated('Migrate to FileHitMapsFormatter.prettyPrint')
   @override
   Future<String> format(Map<String, Map<int, int>> hitmap) {
     return hitmap.map((key, value) => MapEntry(key, HitMap(value))).prettyPrint(

--- a/lib/src/formatter.dart
+++ b/lib/src/formatter.dart
@@ -9,8 +9,7 @@ import 'hitmap.dart';
 
 abstract class Formatter {
   /// Returns the formatted coverage data.
-  ///
-  /// DEPRECATED: Migrate to formatV2.
+  @Deprecated('Migrate to formatV2')
   Future<String> format(Map<String, Map<int, int>> hitmap);
 
   /// Returns the formatted coverage data.

--- a/lib/src/formatter.dart
+++ b/lib/src/formatter.dart
@@ -10,7 +10,7 @@ import 'hitmap.dart';
 abstract class Formatter {
   /// Returns the formatted coverage data.
   ///
-  /// [DEPRECATED] Migrate to formatV2.
+  /// DEPRECATED: Migrate to formatV2.
   Future<String> format(Map<String, Map<int, int>> hitmap);
 
   /// Returns the formatted coverage data.

--- a/lib/src/hitmap.dart
+++ b/lib/src/hitmap.dart
@@ -164,36 +164,6 @@ class HitMap {
     }
     return globalHitmap;
   }
-
-  List<T> _flattenMap<T>(Map map) {
-    final kvs = <T>[];
-    map.forEach((k, v) {
-      kvs.add(k as T);
-      kvs.add(v as T);
-    });
-    return kvs;
-  }
-
-  /// Returns a JSON hit map backward-compatible with pre-1.16.0 SDKs.
-  Map<String, dynamic> toJson(Uri scriptUri) {
-    final json = <String, dynamic>{};
-    json['source'] = '$scriptUri';
-    json['script'] = {
-      'type': '@Script',
-      'fixedId': true,
-      'id': 'libraries/1/scripts/${Uri.encodeComponent(scriptUri.toString())}',
-      'uri': '$scriptUri',
-      '_kind': 'library',
-    };
-    json['hits'] = _flattenMap<int>(lineHits);
-    if (funcHits != null) {
-      json['funcHits'] = _flattenMap<int>(funcHits!);
-    }
-    if (funcNames != null) {
-      json['funcNames'] = _flattenMap<dynamic>(funcNames!);
-    }
-    return json;
-  }
 }
 
 extension FileHitMaps on Map<String, HitMap> {
@@ -298,9 +268,39 @@ Future<Map<String, Map<int, int>>> parseCoverage(
 }
 
 /// Returns a JSON hit map backward-compatible with pre-1.16.0 SDKs.
-@Deprecated('Migrate to HitMap.toJson')
+@Deprecated('Will be removed in 2.0.0')
 Map<String, dynamic> toScriptCoverageJson(Uri scriptUri, Map<int, int> hitMap) {
-  return HitMap(hitMap).toJson(scriptUri);
+  return hitmapToJson(HitMap(hitMap), scriptUri);
+}
+
+List<T> _flattenMap<T>(Map map) {
+  final kvs = <T>[];
+  map.forEach((k, v) {
+    kvs.add(k as T);
+    kvs.add(v as T);
+  });
+  return kvs;
+}
+
+/// Returns a JSON hit map backward-compatible with pre-1.16.0 SDKs.
+Map<String, dynamic> hitmapToJson(HitMap hitmap, Uri scriptUri) {
+  final json = <String, dynamic>{};
+  json['source'] = '$scriptUri';
+  json['script'] = {
+    'type': '@Script',
+    'fixedId': true,
+    'id': 'libraries/1/scripts/${Uri.encodeComponent(scriptUri.toString())}',
+    'uri': '$scriptUri',
+    '_kind': 'library',
+  };
+  json['hits'] = _flattenMap<int>(hitmap.lineHits);
+  if (hitmap.funcHits != null) {
+    json['funcHits'] = _flattenMap<int>(hitmap.funcHits!);
+  }
+  if (hitmap.funcNames != null) {
+    json['funcNames'] = _flattenMap<dynamic>(hitmap.funcNames!);
+  }
+  return json;
 }
 
 /// Sorts the hits array based on the line numbers.

--- a/lib/src/hitmap.dart
+++ b/lib/src/hitmap.dart
@@ -25,7 +25,6 @@ class HitMap {
   /// function coverage info was not gathered.
   Map<int, String>? funcNames;
 
-
   /// Creates a single hitmap from a raw json object.
   ///
   /// Throws away all entries that are not resolvable.
@@ -156,18 +155,15 @@ class HitMap {
       final jsonMap = json.decode(contents) as Map<String, dynamic>;
       if (jsonMap.containsKey('coverage')) {
         final jsonResult = jsonMap['coverage'] as List;
-        globalHitmap.merge(
-          await HitMap.parseJson(
-            jsonResult.cast<Map<String, dynamic>>(),
-            checkIgnoredLines: checkIgnoredLines,
-            packagesPath: packagesPath,
-          )
-        );
+        globalHitmap.merge(await HitMap.parseJson(
+          jsonResult.cast<Map<String, dynamic>>(),
+          checkIgnoredLines: checkIgnoredLines,
+          packagesPath: packagesPath,
+        ));
       }
     }
     return globalHitmap;
   }
-
 
   List<T> _flattenMap<T>(Map map) {
     final kvs = <T>[];
@@ -305,35 +301,6 @@ Future<Map<String, Map<int, int>>> parseCoverage(
 @Deprecated('Migrate to HitMap.toJson')
 Map<String, dynamic> toScriptCoverageJson(Uri scriptUri, Map<int, int> hitMap) {
   return HitMap(hitMap).toJson(scriptUri);
-}
-
-Map<String, dynamic> _toScriptCoverageJsonV2(Uri scriptUri, HitMap hits) {
-  final json = <String, dynamic>{};
-  List<T> flattenMap<T>(Map map) {
-    final kvs = <T>[];
-    map.forEach((k, v) {
-      kvs.add(k as T);
-      kvs.add(v as T);
-    });
-    return kvs;
-  }
-
-  json['source'] = '$scriptUri';
-  json['script'] = {
-    'type': '@Script',
-    'fixedId': true,
-    'id': 'libraries/1/scripts/${Uri.encodeComponent(scriptUri.toString())}',
-    'uri': '$scriptUri',
-    '_kind': 'library',
-  };
-  json['hits'] = flattenMap<int>(hits.lineHits);
-  if (hits.funcHits != null) {
-    json['funcHits'] = flattenMap<int>(hits.funcHits!);
-  }
-  if (hits.funcNames != null) {
-    json['funcNames'] = flattenMap<dynamic>(hits.funcNames!);
-  }
-  return json;
 }
 
 /// Sorts the hits array based on the line numbers.

--- a/lib/src/hitmap.dart
+++ b/lib/src/hitmap.dart
@@ -234,7 +234,7 @@ Future<Map<String, Map<int, int>>> createHitmap(
 }
 
 /// Merges [newMap] into [result].
-@Deprecated('Migrate to HitMap.mergeWith')
+@Deprecated('Migrate to FileHitMaps.merge')
 void mergeHitmaps(
     Map<String, Map<int, int>> newMap, Map<String, Map<int, int>> result) {
   newMap.forEach((file, v) {

--- a/lib/src/hitmap.dart
+++ b/lib/src/hitmap.dart
@@ -11,7 +11,8 @@ import 'package:coverage/src/util.dart';
 /// Contains line and function hit information for a single script.
 class HitMap {
   /// Constructs a HitMap.
-  HitMap([Map<int, int>? _lineHits]) : lineHits = _lineHits ?? <int, int>{};
+  HitMap([Map<int, int>? _lineHits, this.funcHits, this.funcNames])
+      : lineHits = _lineHits ?? <int, int>{};
 
   /// Map from line to hit count for that line.
   final Map<int, int> lineHits;

--- a/lib/src/hitmap.dart
+++ b/lib/src/hitmap.dart
@@ -10,6 +10,9 @@ import 'package:coverage/src/util.dart';
 
 /// Contains line and function hit information for a single script.
 class HitMap {
+  /// Constructs a HitMap.
+  HitMap([Map<int, int>? _lineHits]) : lineHits = _lineHits ?? <int, int>{};
+
   /// Map from line to hit count for that line.
   final Map<int, int> lineHits;
 
@@ -20,9 +23,6 @@ class HitMap {
   /// Map from the first line of each function, to the function name. Null if
   /// function coverage info was not gathered.
   Map<int, String>? funcNames;
-
-  /// Constructs a HitMap.
-  HitMap([Map<int, int>? _lineHits]) : lineHits = _lineHits ?? <int, int>{};
 }
 
 /// Class containing information about a coverage hit.
@@ -43,7 +43,7 @@ class _HitInfo {
 /// Creates a single hitmap from a raw json object. Throws away all entries that
 /// are not resolvable.
 ///
-/// [DEPRECATED] Migrate to createHitmapV2.
+/// DEPRECATED: Migrate to createHitmapV2.
 ///
 /// `jsonResult` is expected to be a List<Map<String, dynamic>>.
 Future<Map<String, Map<int, int>>> createHitmap(
@@ -180,7 +180,7 @@ Future<Map<String, HitMap>> createHitmapV2(
 
 /// Merges [newMap] into [result].
 ///
-/// [DEPRECATED] Migrate to mergeHitmapsV2.
+/// DEPRECATED: Migrate to mergeHitmapsV2.
 void mergeHitmaps(
     Map<String, Map<int, int>> newMap, Map<String, Map<int, int>> result) {
   newMap.forEach((String file, Map<int, int> v) {
@@ -235,7 +235,7 @@ void mergeHitmapsV2(Map<String, HitMap> newMap, Map<String, HitMap> result) {
 
 /// Generates a merged hitmap from a set of coverage JSON files.
 ///
-/// [DEPRECATED] Migrate to parseCoverageV2.
+/// DEPRECATED: Migrate to parseCoverageV2.
 Future<Map<String, Map<int, int>>> parseCoverage(
   Iterable<File> files,
   int _, {
@@ -275,7 +275,7 @@ Future<Map<String, HitMap>> parseCoverageV2(
 
 /// Returns a JSON hit map backward-compatible with pre-1.16.0 SDKs.
 ///
-/// [DEPRECATED] Migrate to toScriptCoverageJsonV2.
+/// DEPRECATED: Migrate to toScriptCoverageJsonV2.
 Map<String, dynamic> toScriptCoverageJson(Uri scriptUri, Map<int, int> hitMap) {
   return toScriptCoverageJsonV2(scriptUri, HitMap(hitMap));
 }

--- a/lib/src/hitmap.dart
+++ b/lib/src/hitmap.dart
@@ -11,8 +11,8 @@ import 'package:coverage/src/util.dart';
 /// Contains line and function hit information for a single script.
 class HitMap {
   /// Constructs a HitMap.
-  HitMap([Map<int, int>? _lineHits, this.funcHits, this.funcNames])
-      : lineHits = _lineHits ?? <int, int>{};
+  HitMap([Map<int, int>? lineHits, this.funcHits, this.funcNames])
+      : lineHits = lineHits ?? {};
 
   /// Map from line to hit count for that line.
   final Map<int, int> lineHits;
@@ -41,12 +41,10 @@ class _HitInfo {
   final int hitCount;
 }
 
-/// Creates a single hitmap from a raw json object. Throws away all entries that
-/// are not resolvable.
+/// Creates a single hitmap from a raw json object.
 ///
-/// DEPRECATED: Migrate to createHitmapV2.
-///
-/// `jsonResult` is expected to be a List<Map<String, dynamic>>.
+/// Throws away all entries that are not resolvable.
+@Deprecated('Migrate to createHitmapV2')
 Future<Map<String, Map<int, int>>> createHitmap(
   List<Map<String, dynamic>> jsonResult, {
   bool checkIgnoredLines = false,
@@ -60,10 +58,9 @@ Future<Map<String, Map<int, int>>> createHitmap(
   return result.map((key, value) => MapEntry(key, value.lineHits));
 }
 
-/// Creates a single hitmap from a raw json object. Throws away all entries that
-/// are not resolvable.
+/// Creates a single hitmap from a raw json object.
 ///
-/// `jsonResult` is expected to be a List<Map<String, dynamic>>.
+/// Throws away all entries that are not resolvable.
 Future<Map<String, HitMap>> createHitmapV2(
   List<Map<String, dynamic>> jsonResult, {
   bool checkIgnoredLines = false,
@@ -180,19 +177,18 @@ Future<Map<String, HitMap>> createHitmapV2(
 }
 
 /// Merges [newMap] into [result].
-///
-/// DEPRECATED: Migrate to mergeHitmapsV2.
+@Deprecated('Migrate to mergeHitmapsV2')
 void mergeHitmaps(
     Map<String, Map<int, int>> newMap, Map<String, Map<int, int>> result) {
-  newMap.forEach((String file, Map<int, int> v) {
+  newMap.forEach((file, v) {
     final fileResult = result[file];
     if (fileResult != null) {
-      v.forEach((int line, int cnt) {
+      v.forEach((line, count) {
         final lineFileResult = fileResult[line];
         if (lineFileResult == null) {
-          fileResult[line] = cnt;
+          fileResult[line] = count;
         } else {
-          fileResult[line] = lineFileResult + cnt;
+          fileResult[line] = lineFileResult + count;
         }
       });
     } else {
@@ -203,16 +199,16 @@ void mergeHitmaps(
 
 /// Merges [newMap] into [result].
 void mergeHitmapsV2(Map<String, HitMap> newMap, Map<String, HitMap> result) {
-  newMap.forEach((String file, HitMap v) {
+  newMap.forEach((file, v) {
     final fileResult = result[file];
     if (fileResult != null) {
       void mergeHitCounts(Map<int, int> src, Map<int, int> dest) {
-        src.forEach((int line, int cnt) {
+        src.forEach((line, count) {
           final lineFileResult = dest[line];
           if (lineFileResult == null) {
-            dest[line] = cnt;
+            dest[line] = count;
           } else {
-            dest[line] = lineFileResult + cnt;
+            dest[line] = lineFileResult + count;
           }
         });
       }
@@ -224,7 +220,7 @@ void mergeHitmapsV2(Map<String, HitMap> newMap, Map<String, HitMap> result) {
       }
       if (v.funcNames != null) {
         fileResult.funcNames ??= <int, String>{};
-        v.funcNames?.forEach((int line, String name) {
+        v.funcNames?.forEach((line, name) {
           fileResult.funcNames![line] = name;
         });
       }
@@ -235,8 +231,7 @@ void mergeHitmapsV2(Map<String, HitMap> newMap, Map<String, HitMap> result) {
 }
 
 /// Generates a merged hitmap from a set of coverage JSON files.
-///
-/// DEPRECATED: Migrate to parseCoverageV2.
+@Deprecated('Migrate to parseCoverageV2')
 Future<Map<String, Map<int, int>>> parseCoverage(
   Iterable<File> files,
   int _, {
@@ -275,8 +270,7 @@ Future<Map<String, HitMap>> parseCoverageV2(
 }
 
 /// Returns a JSON hit map backward-compatible with pre-1.16.0 SDKs.
-///
-/// DEPRECATED: Migrate to toScriptCoverageJsonV2.
+@Deprecated('Migrate to toScriptCoverageJsonV2')
 Map<String, dynamic> toScriptCoverageJson(Uri scriptUri, Map<int, int> hitMap) {
   return toScriptCoverageJsonV2(scriptUri, HitMap(hitMap));
 }

--- a/test/collect_coverage_test.dart
+++ b/test/collect_coverage_test.dart
@@ -235,6 +235,52 @@ void main() {
       await tempDir.delete(recursive: true);
     }
   });
+
+  test('mergeHitmaps', () {
+    final resultMap = <String, Map<int, int>>{
+      "foo.dart": {10: 2, 20: 0},
+      "bar.dart": {10: 3, 20: 1, 30: 0},
+    };
+    final newMap = <String, Map<int, int>>{
+      "bar.dart": {10: 2, 20: 0, 40: 3},
+      "baz.dart": {10: 1, 20: 0, 30: 1},
+    };
+    mergeHitmaps(newMap, resultMap);
+    expect(resultMap, <String, Map<int, int>>{
+      "foo.dart": {10: 2, 20: 0},
+      "bar.dart": {10: 5, 20: 1, 30: 0, 40: 3},
+      "baz.dart": {10: 1, 20: 0, 30: 1},
+    });
+  });
+
+  test('mergeHitmapsV2', () {
+    final resultMap = <String, HitMap>{
+      "foo.dart":
+          HitMap({10: 2, 20: 0}, {15: 0, 25: 1}, {15: "bobble", 25: "cobble"}),
+      "bar.dart": HitMap(
+          {10: 3, 20: 1, 30: 0}, {15: 5, 25: 0}, {15: "gobble", 25: "wobble"}),
+    };
+    final newMap = <String, HitMap>{
+      "bar.dart": HitMap(
+          {10: 2, 20: 0, 40: 3}, {15: 1, 35: 4}, {15: "gobble", 35: "dobble"}),
+      "baz.dart": HitMap(
+          {10: 1, 20: 0, 30: 1}, {15: 0, 25: 2}, {15: "lobble", 25: "zobble"}),
+    };
+    mergeHitmapsV2(newMap, resultMap);
+    expect(resultMap["foo.dart"]?.lineHits, <int, int>{10: 2, 20: 0});
+    expect(resultMap["foo.dart"]?.funcHits, <int, int>{15: 0, 25: 1});
+    expect(resultMap["foo.dart"]?.funcNames,
+        <int, String>{15: "bobble", 25: "cobble"});
+    expect(resultMap["bar.dart"]?.lineHits,
+        <int, int>{10: 5, 20: 1, 30: 0, 40: 3});
+    expect(resultMap["bar.dart"]?.funcHits, <int, int>{15: 6, 25: 0, 35: 4});
+    expect(resultMap["bar.dart"]?.funcNames,
+        <int, String>{15: "gobble", 25: "wobble", 35: "dobble"});
+    expect(resultMap["baz.dart"]?.lineHits, <int, int>{10: 1, 20: 0, 30: 1});
+    expect(resultMap["baz.dart"]?.funcHits, <int, int>{15: 0, 25: 2});
+    expect(resultMap["baz.dart"]?.funcNames,
+        <int, String>{15: "lobble", 25: "zobble"});
+  });
 }
 
 String? _coverageData;

--- a/test/collect_coverage_test.dart
+++ b/test/collect_coverage_test.dart
@@ -73,6 +73,7 @@ void main() {
         ]
       }
     ];
+    // ignore: deprecated_member_use_from_same_package
     final hitMap = await createHitmap(
       coverage.cast<Map<String, dynamic>>(),
     );
@@ -189,6 +190,7 @@ void main() {
       final coverageResults = await _getCoverageResult();
       await outputFile.writeAsString(coverageResults, flush: true);
 
+      // ignore: deprecated_member_use_from_same_package
       final parsedResult = await parseCoverage([outputFile], 1);
 
       expect(parsedResult, contains(_sampleAppFileUri));
@@ -245,6 +247,7 @@ void main() {
       "bar.dart": {10: 2, 20: 0, 40: 3},
       "baz.dart": {10: 1, 20: 0, 30: 1},
     };
+    // ignore: deprecated_member_use_from_same_package
     mergeHitmaps(newMap, resultMap);
     expect(resultMap, <String, Map<int, int>>{
       "foo.dart": {10: 2, 20: 0},

--- a/test/collect_coverage_test.dart
+++ b/test/collect_coverage_test.dart
@@ -81,7 +81,7 @@ void main() {
     expect(hitMap['foo'], expectedHits);
   });
 
-  test('createHitmapV2 returns a sorted hitmap', () async {
+  test('HitMap.parseJson returns a sorted hitmap', () async {
     final coverage = [
       {
         'source': 'foo',
@@ -105,18 +105,18 @@ void main() {
         ]
       }
     ];
-    final hitMap = await createHitmapV2(
+    final hitMap = await HitMap.parseJson(
       coverage.cast<Map<String, dynamic>>(),
     );
     final expectedHits = {15: 1, 16: 2, 17: 2, 45: 1, 46: 1, 49: 0, 50: 0};
     expect(hitMap['foo']?.lineHits, expectedHits);
   });
 
-  test('createHitmapV2', () async {
+  test('HitMap.parseJson', () async {
     final resultString = await _collectCoverage(true);
     final jsonResult = json.decode(resultString) as Map<String, dynamic>;
     final coverage = jsonResult['coverage'] as List;
-    final hitMap = await createHitmapV2(
+    final hitMap = await HitMap.parseJson(
       coverage.cast<Map<String, dynamic>>(),
     );
     expect(hitMap, contains(_sampleAppFileUri));
@@ -200,7 +200,7 @@ void main() {
     }
   });
 
-  test('parseCoverageV2', () async {
+  test('HitMap.parseFiles', () async {
     final tempDir = await Directory.systemTemp.createTemp('coverage.test.');
 
     try {
@@ -209,7 +209,7 @@ void main() {
       final coverageResults = await _getCoverageResult();
       await outputFile.writeAsString(coverageResults, flush: true);
 
-      final parsedResult = await parseCoverageV2([outputFile], 1);
+      final parsedResult = await HitMap.parseFiles([outputFile]);
 
       expect(parsedResult, contains(_sampleAppFileUri));
       expect(parsedResult, contains(_isolateLibFileUri));
@@ -218,7 +218,7 @@ void main() {
     }
   });
 
-  test('parseCoverageV2 with packagesPath and checkIgnoredLines', () async {
+  test('HitMap.parseFiles with packagesPath and checkIgnoredLines', () async {
     final tempDir = await Directory.systemTemp.createTemp('coverage.test.');
 
     try {
@@ -227,7 +227,7 @@ void main() {
       final coverageResults = await _getCoverageResult();
       await outputFile.writeAsString(coverageResults, flush: true);
 
-      final parsedResult = await parseCoverageV2([outputFile], 1,
+      final parsedResult = await HitMap.parseFiles([outputFile],
           packagesPath: '.packages', checkIgnoredLines: true);
 
       // This file has ignore:coverage-file.
@@ -256,7 +256,7 @@ void main() {
     });
   });
 
-  test('mergeHitmapsV2', () {
+  test('FileHitMaps.merge', () {
     final resultMap = <String, HitMap>{
       "foo.dart":
           HitMap({10: 2, 20: 0}, {15: 0, 25: 1}, {15: "bobble", 25: "cobble"}),
@@ -269,7 +269,7 @@ void main() {
       "baz.dart": HitMap(
           {10: 1, 20: 0, 30: 1}, {15: 0, 25: 2}, {15: "lobble", 25: "zobble"}),
     };
-    mergeHitmapsV2(newMap, resultMap);
+    resultMap.merge(newMap);
     expect(resultMap["foo.dart"]?.lineHits, <int, int>{10: 2, 20: 0});
     expect(resultMap["foo.dart"]?.funcHits, <int, int>{15: 0, 25: 1});
     expect(resultMap["foo.dart"]?.funcNames,

--- a/test/lcov_test.dart
+++ b/test/lcov_test.dart
@@ -60,52 +60,44 @@ void main() {
       expect(res, contains(p.absolute(p.join('lib', 'src', 'util.dart'))));
     });
 
-    test('formatV2()', () async {
+    test('formatLcov()', () async {
       final hitmap = await _getHitMap();
 
       final resolver = Resolver(packagesPath: '.packages');
-      final formatter = LcovFormatter(resolver);
-
-      final res = await formatter.formatV2(hitmap);
+      final res = hitmap.formatLcov(resolver);
 
       expect(res, contains(p.absolute(_sampleAppPath)));
       expect(res, contains(p.absolute(_isolateLibPath)));
       expect(res, contains(p.absolute(p.join('lib', 'src', 'util.dart'))));
     });
 
-    test('formatV2() includes files in reportOn list', () async {
+    test('formatLcov() includes files in reportOn list', () async {
       final hitmap = await _getHitMap();
 
       final resolver = Resolver(packagesPath: '.packages');
-      final formatter = LcovFormatter(resolver, reportOn: ['lib/', 'test/']);
-
-      final res = await formatter.formatV2(hitmap);
+      final res = hitmap.formatLcov(resolver, reportOn: ['lib/', 'test/']);
 
       expect(res, contains(p.absolute(_sampleAppPath)));
       expect(res, contains(p.absolute(_isolateLibPath)));
       expect(res, contains(p.absolute(p.join('lib', 'src', 'util.dart'))));
     });
 
-    test('formatV2() excludes files not in reportOn list', () async {
+    test('formatLcov() excludes files not in reportOn list', () async {
       final hitmap = await _getHitMap();
 
       final resolver = Resolver(packagesPath: '.packages');
-      final formatter = LcovFormatter(resolver, reportOn: ['lib/']);
-
-      final res = await formatter.formatV2(hitmap);
+      final res = hitmap.formatLcov(resolver, reportOn: ['lib/']);
 
       expect(res, isNot(contains(p.absolute(_sampleAppPath))));
       expect(res, isNot(contains(p.absolute(_isolateLibPath))));
       expect(res, contains(p.absolute(p.join('lib', 'src', 'util.dart'))));
     });
 
-    test('formatV2() uses paths relative to basePath', () async {
+    test('formatLcov() uses paths relative to basePath', () async {
       final hitmap = await _getHitMap();
 
       final resolver = Resolver(packagesPath: '.packages');
-      final formatter = LcovFormatter(resolver, basePath: p.absolute('lib'));
-
-      final res = await formatter.formatV2(hitmap);
+      final res = hitmap.formatLcov(resolver, basePath: p.absolute('lib'));
 
       expect(
           res, isNot(contains(p.absolute(p.join('lib', 'src', 'util.dart')))));
@@ -141,13 +133,11 @@ void main() {
       expect(hitCount, greaterThanOrEqualTo(1));
     });
 
-    test('formatV2()', () async {
+    test('prettyPrint()', () async {
       final hitmap = await _getHitMap();
 
       final resolver = Resolver(packagesPath: '.packages');
-      final formatter = PrettyPrintFormatter(resolver, Loader());
-
-      final res = await formatter.formatV2(hitmap);
+      final res = await hitmap.prettyPrint(resolver, Loader());
 
       expect(res, contains(p.absolute(_sampleAppPath)));
       expect(res, contains(p.absolute(_isolateLibPath)));
@@ -166,42 +156,36 @@ void main() {
       expect(hitCount, greaterThanOrEqualTo(1));
     });
 
-    test('formatV2() includes files in reportOn list', () async {
+    test('prettyPrint() includes files in reportOn list', () async {
       final hitmap = await _getHitMap();
 
       final resolver = Resolver(packagesPath: '.packages');
-      final formatter =
-          PrettyPrintFormatter(resolver, Loader(), reportOn: ['lib/', 'test/']);
-
-      final res = await formatter.formatV2(hitmap);
+      final res = await hitmap
+          .prettyPrint(resolver, Loader(), reportOn: ['lib/', 'test/']);
 
       expect(res, contains(p.absolute(_sampleAppPath)));
       expect(res, contains(p.absolute(_isolateLibPath)));
       expect(res, contains(p.absolute(p.join('lib', 'src', 'util.dart'))));
     });
 
-    test('formatV2() excludes files not in reportOn list', () async {
+    test('prettyPrint() excludes files not in reportOn list', () async {
       final hitmap = await _getHitMap();
 
       final resolver = Resolver(packagesPath: '.packages');
-      final formatter =
-          PrettyPrintFormatter(resolver, Loader(), reportOn: ['lib/']);
-
-      final res = await formatter.formatV2(hitmap);
+      final res =
+          await hitmap.prettyPrint(resolver, Loader(), reportOn: ['lib/']);
 
       expect(res, isNot(contains(p.absolute(_sampleAppPath))));
       expect(res, isNot(contains(p.absolute(_isolateLibPath))));
       expect(res, contains(p.absolute(p.join('lib', 'src', 'util.dart'))));
     });
 
-    test('formatV2() functions', () async {
+    test('prettyPrint() functions', () async {
       final hitmap = await _getHitMap();
 
       final resolver = Resolver(packagesPath: '.packages');
-      final formatter =
-          PrettyPrintFormatter(resolver, Loader(), reportFuncs: true);
-
-      final res = await formatter.formatV2(hitmap);
+      final res =
+          await hitmap.prettyPrint(resolver, Loader(), reportFuncs: true);
 
       expect(res, contains(p.absolute(_sampleAppPath)));
       expect(res, contains(p.absolute(_isolateLibPath)));

--- a/test/lcov_test.dart
+++ b/test/lcov_test.dart
@@ -49,10 +49,10 @@ void main() {
       final hitmap = await _getHitMap();
 
       final resolver = Resolver(packagesPath: '.packages');
+      // ignore: deprecated_member_use_from_same_package
       final formatter = LcovFormatter(resolver);
 
       final res = await formatter
-          // ignore: deprecated_member_use_from_same_package
           .format(hitmap.map((key, value) => MapEntry(key, value.lineHits)));
 
       expect(res, contains(p.absolute(_sampleAppPath)));
@@ -110,10 +110,10 @@ void main() {
       final hitmap = await _getHitMap();
 
       final resolver = Resolver(packagesPath: '.packages');
+      // ignore: deprecated_member_use_from_same_package
       final formatter = PrettyPrintFormatter(resolver, Loader());
 
       final res = await formatter
-          // ignore: deprecated_member_use_from_same_package
           .format(hitmap.map((key, value) => MapEntry(key, value.lineHits)));
 
       expect(res, contains(p.absolute(_sampleAppPath)));

--- a/test/lcov_test.dart
+++ b/test/lcov_test.dart
@@ -52,6 +52,7 @@ void main() {
       final formatter = LcovFormatter(resolver);
 
       final res = await formatter
+          // ignore: deprecated_member_use_from_same_package
           .format(hitmap.map((key, value) => MapEntry(key, value.lineHits)));
 
       expect(res, contains(p.absolute(_sampleAppPath)));
@@ -120,6 +121,7 @@ void main() {
       final formatter = PrettyPrintFormatter(resolver, Loader());
 
       final res = await formatter
+          // ignore: deprecated_member_use_from_same_package
           .format(hitmap.map((key, value) => MapEntry(key, value.lineHits)));
 
       expect(res, contains(p.absolute(_sampleAppPath)));

--- a/test/lcov_test.dart
+++ b/test/lcov_test.dart
@@ -248,7 +248,7 @@ Future<Map<String, HitMap>> _getHitMap() async {
   // collect hit map.
   final coverageJson = (await collect(serviceUri, true, true, false, <String>{},
       functionCoverage: true))['coverage'] as List<Map<String, dynamic>>;
-  final hitMap = createHitmapV2(coverageJson);
+  final hitMap = HitMap.parseJson(coverageJson);
 
   // wait for sample app to terminate.
   final exitCode = await sampleProcess.exitCode;

--- a/test/run_and_collect_test.dart
+++ b/test/run_and_collect_test.dart
@@ -38,7 +38,7 @@ void main() {
       expect(sampleCoverageData['hits'], isNotEmpty);
     }
 
-    final hitMap = await createHitmapV2(coverage, checkIgnoredLines: true);
+    final hitMap = await HitMap.parseJson(coverage, checkIgnoredLines: true);
     expect(hitMap, isNot(contains(_sampleAppFileUri)));
 
     final actualHitMap = hitMap[_isolateLibFileUri];

--- a/test/run_and_collect_test.dart
+++ b/test/run_and_collect_test.dart
@@ -38,7 +38,7 @@ void main() {
       expect(sampleCoverageData['hits'], isNotEmpty);
     }
 
-    final hitMap = await createHitmap(coverage, checkIgnoredLines: true);
+    final hitMap = await createHitmapV2(coverage, checkIgnoredLines: true);
     expect(hitMap, isNot(contains(_sampleAppFileUri)));
 
     final actualHitMap = hitMap[_isolateLibFileUri];


### PR DESCRIPTION
There were 5 functions that were changed in a backwards incompatible way in #348: `createHitmap`, `mergeHitmaps`, `parseCoverage`, `toScriptCoverageJson`, and `Formatter.format`.

This change makes #348 backwards compatible by renaming those newer functions, and adding versions of all those functions with the same signature as before. Most of these legacy functions simply wrap the newer versions and convert the `HitMap` back to a `Map<int, int>`.

| Legacy | New |
| --- | --- |
| createHitmap | HitMap.parseJson |
| mergeHitmaps | FileHitMaps.merge |
| parseCoverage | HitMap.parseFiles |
| toScriptCoverageJson | deprecated, no replacement |
| Formatter | deprecated, no replacement |
| PrettyPrintFormatter | FileHitMapsFormatter.prettyPrint |
| LcovFormatter | FileHitMapsFormatter.formatLcov |