### PR TITLE
Branch coverage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,8 +10,8 @@
   line level.
 * Update `--lcov` (abbr `-l`) in format_coverage to output branch level
   coverage, in addition to line level.
-* Add an optional bool flag to `collect` that controls whether branch coverage
-  is collected.
+* Add an optional bool flag to `collect` and `runAndCollect` that controls
+  whether branch coverage is collected.
 * Add a `branchHits` field to `HitMap`.
 * Add support for scraping the service URI from the new Dart VM service message.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,8 +10,8 @@
   line level.
 * Update `--lcov` (abbr `-l`) in format_coverage to output branch level
   coverage, in addition to line level.
-* Add an optional bool flag to `collect` and `runAndCollect` that controls
-  whether branch coverage is collected.
+* Add an optional bool flag to `collect` that controls whether branch coverage
+  is collected.
 * Add a `branchHits` field to `HitMap`.
 * Add support for scraping the service URI from the new Dart VM service message.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,19 @@
+## 1.2.0-dev
+
+* Support branch level coverage information, when running tests in the Dart VM.
+  This is not supported for web tests yet.
+* Add flag `--branch-coverage` (abbr `-b`) to collect_coverage that collects
+  branch coverage information. The VM must also be run with the
+  `--branch-coverage` flag.
+* Add flag `--pretty-print-branch` to format_coverage that works
+  similarly to pretty print, but outputs branch level coverage, rather than
+  line level.
+* Update `--lcov` (abbr `-l`) in format_coverage to output branch level
+  coverage, in addition to line level.
+* Add an optional bool flag to `collect` that controls whether branch coverage
+  is collected.
+* Add a `branchHits` field to `HitMap`.
+
 ## 1.1.0 - 2022-1-18
 
 * Support function level coverage information, when running tests in the Dart

--- a/README.md
+++ b/README.md
@@ -61,3 +61,30 @@ collected. If `--sdk-root` is set, Dart SDK coverage will also be output.
 - `// coverage:ignore-line` to ignore one line.
 - `// coverage:ignore-start` and `// coverage:ignore-end` to ignore range of lines inclusive.
 - `// coverage:ignore-file` to ignore the whole file.
+
+#### Function and branch coverage
+
+To gather function level coverage information, pass `--function-coverage` to
+collect_coverage:
+
+```
+dart --pause-isolates-on-exit --disable-service-auth-codes --enable-vm-service=NNNN script.dart
+pub global run coverage:collect_coverage --uri=http://... -o coverage.json --resume-isolates --function-coverage
+```
+
+To gather branch level coverage information, pass `--branch-coverage` to *both*
+collect_coverage and the Dart command you're gathering coverage from:
+
+```
+dart --pause-isolates-on-exit --disable-service-auth-codes --enable-vm-service=NNNN --branch-coverage script.dart
+pub global run coverage:collect_coverage --uri=http://... -o coverage.json --resume-isolates --branch-coverage
+```
+
+Branch coverage requires Dart VM 2.17.0, with service API v3.56. Function,
+branch, and line coverage can all be gathered at the same time, by combining
+those flags:
+
+```
+dart --pause-isolates-on-exit --disable-service-auth-codes --enable-vm-service=NNNN --branch-coverage script.dart
+pub global run coverage:collect_coverage --uri=http://... -o coverage.json --resume-isolates --function-coverage --branch-coverage
+```

--- a/bin/collect_coverage.dart
+++ b/bin/collect_coverage.dart
@@ -21,7 +21,9 @@ Future<void> main(List<String> arguments) async {
   await Chain.capture(() async {
     final coverage = await collect(options.serviceUri, options.resume,
         options.waitPaused, options.includeDart, options.scopedOutput,
-        timeout: options.timeout, functionCoverage: options.functionCoverage);
+        timeout: options.timeout,
+        functionCoverage: options.functionCoverage,
+        branchCoverage: options.branchCoverage);
     options.out.write(json.encode(coverage));
     await options.out.close();
   }, onError: (dynamic error, Chain chain) {
@@ -34,8 +36,16 @@ Future<void> main(List<String> arguments) async {
 }
 
 class Options {
-  Options(this.serviceUri, this.out, this.timeout, this.waitPaused, this.resume,
-      this.includeDart, this.functionCoverage, this.scopedOutput);
+  Options(
+      this.serviceUri,
+      this.out,
+      this.timeout,
+      this.waitPaused,
+      this.resume,
+      this.includeDart,
+      this.functionCoverage,
+      this.branchCoverage,
+      this.scopedOutput);
 
   final Uri serviceUri;
   final IOSink out;
@@ -44,6 +54,7 @@ class Options {
   final bool resume;
   final bool includeDart;
   final bool functionCoverage;
+  final bool branchCoverage;
   final Set<String> scopedOutput;
 }
 
@@ -75,6 +86,11 @@ Options _parseArgs(List<String> arguments) {
         abbr: 'd', defaultsTo: false, help: 'include "dart:" libraries')
     ..addFlag('function-coverage',
         abbr: 'f', defaultsTo: false, help: 'Collect function coverage info')
+    ..addFlag('branch-coverage',
+        abbr: 'b',
+        defaultsTo: false,
+        help: 'Collect branch coverage info (Dart VM must also be run with '
+            '--branch-coverage for this to work)')
     ..addFlag('help', abbr: 'h', negatable: false, help: 'show this help');
 
   final args = parser.parse(arguments);
@@ -127,6 +143,7 @@ Options _parseArgs(List<String> arguments) {
     args['resume-isolates'] as bool,
     args['include-dart'] as bool,
     args['function-coverage'] as bool,
+    args['branch-coverage'] as bool,
     scopedOutput.toSet(),
   );
 }

--- a/bin/format_coverage.dart
+++ b/bin/format_coverage.dart
@@ -78,7 +78,9 @@ Future<void> main(List<String> arguments) async {
   final loader = Loader();
   if (env.prettyPrint) {
     output = await hitmap.prettyPrint(resolver, loader,
-        reportOn: env.reportOn, reportFuncs: env.prettyPrintFunc, reportBranches: env.prettyPrintBranch);
+        reportOn: env.reportOn,
+        reportFuncs: env.prettyPrintFunc,
+        reportBranches: env.prettyPrintBranch);
   } else {
     assert(env.lcov);
     output = hitmap.formatLcov(resolver,
@@ -223,7 +225,10 @@ Environment parseArgs(List<String> arguments) {
   var prettyPrint = args['pretty-print'] as bool;
   final prettyPrintFunc = args['pretty-print-func'] as bool;
   final prettyPrintBranch = args['pretty-print-branch'] as bool;
-  final numModesChosen = (prettyPrint ? 1 : 0) + (prettyPrintFunc ? 1 : 0) + (prettyPrintBranch ? 1 : 0) + (lcov ? 1 : 0);
+  final numModesChosen = (prettyPrint ? 1 : 0) +
+      (prettyPrintFunc ? 1 : 0) +
+      (prettyPrintBranch ? 1 : 0) +
+      (lcov ? 1 : 0);
   if (numModesChosen > 1) {
     fail('Choose one of the pretty-print modes or lcov output');
   }

--- a/bin/format_coverage.dart
+++ b/bin/format_coverage.dart
@@ -21,6 +21,7 @@ class Environment {
     required this.packagesPath,
     required this.prettyPrint,
     required this.prettyPrintFunc,
+    required this.prettyPrintBranch,
     required this.reportOn,
     required this.sdkRoot,
     required this.verbose,
@@ -37,6 +38,7 @@ class Environment {
   String? packagesPath;
   bool prettyPrint;
   bool prettyPrintFunc;
+  bool prettyPrintBranch;
   List<String>? reportOn;
   String? sdkRoot;
   bool verbose;
@@ -74,9 +76,9 @@ Future<void> main(List<String> arguments) async {
       ? BazelResolver(workspacePath: env.bazelWorkspace)
       : Resolver(packagesPath: env.packagesPath, sdkRoot: env.sdkRoot);
   final loader = Loader();
-  if (env.prettyPrint || env.prettyPrintFunc) {
+  if (env.prettyPrint) {
     output = await hitmap.prettyPrint(resolver, loader,
-        reportOn: env.reportOn, reportFuncs: env.prettyPrintFunc);
+        reportOn: env.reportOn, reportFuncs: env.prettyPrintFunc, reportBranches: env.prettyPrintBranch);
   } else {
     assert(env.lcov);
     output = hitmap.formatLcov(resolver,
@@ -135,6 +137,9 @@ Environment parseArgs(List<String> arguments) {
       abbr: 'f',
       negatable: false,
       help: 'convert function coverage data to pretty print format');
+  parser.addFlag('pretty-print-branch',
+      negatable: false,
+      help: 'convert branch coverage data to pretty print format');
   parser.addFlag('lcov',
       abbr: 'l',
       negatable: false,
@@ -217,12 +222,14 @@ Environment parseArgs(List<String> arguments) {
   final lcov = args['lcov'] as bool;
   var prettyPrint = args['pretty-print'] as bool;
   final prettyPrintFunc = args['pretty-print-func'] as bool;
-  if ((prettyPrint ? 1 : 0) + (prettyPrintFunc ? 1 : 0) + (lcov ? 1 : 0) > 1) {
+  final prettyPrintBranch = args['pretty-print-branch'] as bool;
+  final numModesChosen = (prettyPrint ? 1 : 0) + (prettyPrintFunc ? 1 : 0) + (prettyPrintBranch ? 1 : 0) + (lcov ? 1 : 0);
+  if (numModesChosen > 1) {
     fail('Choose one of the pretty-print modes or lcov output');
   }
 
-  // Use pretty-print either explicitly or by default.
-  if (!lcov && !prettyPrintFunc) prettyPrint = true;
+  // The pretty printer is used by all modes other than lcov.
+  if (!lcov) prettyPrint = true;
 
   int workers;
   try {
@@ -244,6 +251,7 @@ Environment parseArgs(List<String> arguments) {
       packagesPath: packagesPath,
       prettyPrint: prettyPrint,
       prettyPrintFunc: prettyPrintFunc,
+      prettyPrintBranch: prettyPrintBranch,
       reportOn: reportOn,
       sdkRoot: sdkRoot,
       verbose: verbose,

--- a/lib/src/collect.dart
+++ b/lib/src/collect.dart
@@ -140,7 +140,7 @@ Future<Map<String, dynamic>> _getAllCoverage(
         // Skip scripts which should not be included in the report.
         if (!scopedOutput.contains(scope)) continue;
         final scriptReport = await service.getSourceReport(
-            isolateRef.id!, <String>[SourceReportKind.kCoverage],
+            isolateRef.id!, sourceReportKinds,
             forceCompile: true,
             scriptId: script.id,
             reportLines: reportLines ? true : null);
@@ -151,7 +151,7 @@ Future<Map<String, dynamic>> _getAllCoverage(
     } else {
       final isolateReport = await service.getSourceReport(
         isolateRef.id!,
-        <String>[SourceReportKind.kCoverage],
+        sourceReportKinds,
         forceCompile: true,
         reportLines: reportLines ? true : null,
       );

--- a/lib/src/formatter.dart
+++ b/lib/src/formatter.dart
@@ -84,6 +84,7 @@ extension FileHitMapsFormatter on Map<String, HitMap> {
       final lineHits = v.lineHits;
       final funcHits = v.funcHits;
       final funcNames = v.funcNames;
+      final branchHits = v.branchHits;
       var source = resolver.resolve(entry.key);
       if (source == null) {
         continue;
@@ -115,6 +116,11 @@ extension FileHitMapsFormatter on Map<String, HitMap> {
       }
       buf.write('LF:${lineHits.length}\n');
       buf.write('LH:${lineHits.values.where((v) => v > 0).length}\n');
+      if (branchHits != null) {
+        for (final k in branchHits.keys.toList()..sort()) {
+          buf.write('BRDA:$k,0,0,${branchHits[k]}\n');
+        }
+      }
       buf.write('end_of_record\n');
     }
 
@@ -146,7 +152,11 @@ extension FileHitMapsFormatter on Map<String, HitMap> {
             'missing branch coverage information. Did you run '
             'collect_coverage with the --branch-coverage flag?';
       }
-      final hits = reportFuncs ? v.funcHits! : reportBranches ? v.branchHits! : v.lineHits;
+      final hits = reportFuncs
+          ? v.funcHits!
+          : reportBranches
+              ? v.branchHits!
+              : v.lineHits;
       final source = resolver.resolve(entry.key);
       if (source == null) {
         continue;

--- a/lib/src/formatter.dart
+++ b/lib/src/formatter.dart
@@ -130,6 +130,7 @@ extension FileHitMapsFormatter on Map<String, HitMap> {
     Loader loader, {
     List<String>? reportOn,
     bool reportFuncs = false,
+    bool reportBranches = false,
   }) async {
     final pathFilter = _getPathFilter(reportOn);
     final buf = StringBuffer();
@@ -140,7 +141,12 @@ extension FileHitMapsFormatter on Map<String, HitMap> {
             'missing function coverage information. Did you run '
             'collect_coverage with the --function-coverage flag?';
       }
-      final hits = reportFuncs ? v.funcHits! : v.lineHits;
+      if (reportBranches && v.branchHits == null) {
+        throw 'Branch coverage formatting was requested, but the hit map is '
+            'missing branch coverage information. Did you run '
+            'collect_coverage with the --branch-coverage flag?';
+      }
+      final hits = reportFuncs ? v.funcHits! : reportBranches ? v.branchHits! : v.lineHits;
       final source = resolver.resolve(entry.key);
       if (source == null) {
         continue;

--- a/lib/src/run_and_collect.dart
+++ b/lib/src/run_and_collect.dart
@@ -13,16 +13,21 @@ Future<Map<String, dynamic>> runAndCollect(String scriptPath,
     {List<String>? scriptArgs,
     bool checked = false,
     bool includeDart = false,
-    bool branchCoverage = false,
     Duration? timeout}) async {
   final dartArgs = [
     '--enable-vm-service',
     '--pause_isolates_on_exit',
-    if (branchCoverage) '--branch-coverage',
-    if (checked) '--checked',
-    scriptPath,
-    if (scriptArgs != null) ...scriptArgs,
   ];
+
+  if (checked) {
+    dartArgs.add('--checked');
+  }
+
+  dartArgs.add(scriptPath);
+
+  if (scriptArgs != null) {
+    dartArgs.addAll(scriptArgs);
+  }
 
   final process = await Process.start('dart', dartArgs);
   final serviceUriCompleter = Completer<Uri>();
@@ -39,8 +44,7 @@ Future<Map<String, dynamic>> runAndCollect(String scriptPath,
   final serviceUri = await serviceUriCompleter.future;
   Map<String, dynamic> coverage;
   try {
-    coverage = await collect(
-        serviceUri, true, branchCoverage, includeDart, <String>{},
+    coverage = await collect(serviceUri, true, true, includeDart, <String>{},
         timeout: timeout);
   } finally {
     await process.stderr.drain();

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -21,3 +21,6 @@ dev_dependencies:
 executables:
   collect_coverage:
   format_coverage:
+dependency_overrides:
+  vm_service:
+    path: /usr/local/google/home/liama/dart-sdk/sdk/pkg/vm_service

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -13,7 +13,8 @@ dependencies:
   path: ^1.8.0
   source_maps: ^0.10.10
   stack_trace: ^1.10.0
-  vm_service: ">=8.1.0 <9.0.0"
+  vm_service:
+    path: /usr/local/google/home/liama/dart-sdk/sdk/pkg/vm_service
 dev_dependencies:
   lints: ^1.0.0
   test: ^1.16.0

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: coverage
-version: 1.1.0
+version: 1.2.0-dev
 description: Coverage data manipulation and formatting
 homepage: https://github.com/dart-lang/coverage
 
@@ -13,7 +13,7 @@ dependencies:
   path: ^1.8.0
   source_maps: ^0.10.10
   stack_trace: ^1.10.0
-  vm_service: ^8.2.0
+  vm_service: ">=8.2.0 <9.0.0"
 dev_dependencies:
   lints: ^1.0.0
   test: ^1.16.0
@@ -21,6 +21,3 @@ dev_dependencies:
 executables:
   collect_coverage:
   format_coverage:
-dependency_overrides:
-  vm_service:
-    path: /usr/local/google/home/liama/dart-sdk/sdk/pkg/vm_service

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -13,8 +13,7 @@ dependencies:
   path: ^1.8.0
   source_maps: ^0.10.10
   stack_trace: ^1.10.0
-  vm_service:
-    path: /usr/local/google/home/liama/dart-sdk/sdk/pkg/vm_service
+  vm_service: ^8.2.0
 dev_dependencies:
   lints: ^1.0.0
   test: ^1.16.0

--- a/test/collect_coverage_api_test.dart
+++ b/test/collect_coverage_api_test.dart
@@ -114,17 +114,12 @@ void main() {
       return map;
     });
 
-    if (platformVersionCheck(2, 17)) {
-      // Dart VM versions before 2.17 don't support branch coverage.
-      for (var sampleCoverageData in sources[_sampleAppFileUri]!) {
-        expect(sampleCoverageData['branchHits'], isNotEmpty);
-      }
-
-      for (var sampleCoverageData in sources[_isolateLibFileUri]!) {
-        expect(sampleCoverageData['branchHits'], isNotEmpty);
-      }
-    }
-  });
+    // Dart VM versions before 2.17 don't support branch coverage.
+    expect(sources[_sampleAppFileUri],
+        everyElement(containsPair('branchHits', isNotEmpty)));
+    expect(sources[_isolateLibFileUri],
+        everyElement(containsPair('branchHits', isNotEmpty)));
+  }, skip: !platformVersionCheck(2, 17));
 }
 
 Future<Map<String, dynamic>> _collectCoverage(

--- a/test/collect_coverage_api_test.dart
+++ b/test/collect_coverage_api_test.dart
@@ -98,12 +98,37 @@ void main() {
       expect(sampleCoverageData['funcHits'], isNotEmpty);
     }
   });
+
+  test('collect_coverage_api with branch coverage', () async {
+    final json = await _collectCoverage(branchCoverage: true);
+    expect(json.keys, unorderedEquals(<String>['type', 'coverage']));
+    expect(json, containsPair('type', 'CodeCoverage'));
+
+    final coverage = json['coverage'] as List;
+    expect(coverage, isNotEmpty);
+
+    final sources = coverage.cast<Map>().fold(<String, List<Map>>{},
+        (Map<String, List<Map>> map, value) {
+      final sourceUri = value['source'] as String;
+      map.putIfAbsent(sourceUri, () => <Map>[]).add(value);
+      return map;
+    });
+
+    for (var sampleCoverageData in sources[_sampleAppFileUri]!) {
+      expect(sampleCoverageData['branchHits'], isNotEmpty);
+    }
+
+    for (var sampleCoverageData in sources[_isolateLibFileUri]!) {
+      expect(sampleCoverageData['branchHits'], isNotEmpty);
+    }
+  });
 }
 
 Future<Map<String, dynamic>> _collectCoverage(
     {Set<String> scopedOutput = const {},
     bool isolateIds = false,
-    bool functionCoverage = false}) async {
+    bool functionCoverage = false,
+    bool branchCoverage = false}) async {
   final openPort = await getOpenPort();
 
   // run the sample app, with the right flags
@@ -129,5 +154,6 @@ Future<Map<String, dynamic>> _collectCoverage(
   return collect(serviceUri, true, true, false, scopedOutput,
       timeout: timeout,
       isolateIds: isolateIdSet,
-      functionCoverage: functionCoverage);
+      functionCoverage: functionCoverage,
+      branchCoverage: branchCoverage);
 }

--- a/test/collect_coverage_api_test.dart
+++ b/test/collect_coverage_api_test.dart
@@ -114,12 +114,15 @@ void main() {
       return map;
     });
 
-    for (var sampleCoverageData in sources[_sampleAppFileUri]!) {
-      expect(sampleCoverageData['branchHits'], isNotEmpty);
-    }
+    if (platformVersionCheck(2, 17)) {
+      // Dart VM versions before 2.17 don't support branch coverage.
+      for (var sampleCoverageData in sources[_sampleAppFileUri]!) {
+        expect(sampleCoverageData['branchHits'], isNotEmpty);
+      }
 
-    for (var sampleCoverageData in sources[_isolateLibFileUri]!) {
-      expect(sampleCoverageData['branchHits'], isNotEmpty);
+      for (var sampleCoverageData in sources[_isolateLibFileUri]!) {
+        expect(sampleCoverageData['branchHits'], isNotEmpty);
+      }
     }
   });
 }

--- a/test/collect_coverage_test.dart
+++ b/test/collect_coverage_test.dart
@@ -179,8 +179,11 @@ void main() {
       28: 'fooAsync',
       38: 'isolateTask'
     });
-    expect(isolateFile?.branchHits,
-        {11: 1, 12: 1, 15: 0, 19: 1, 23: 1, 28: 1, 32: 0, 38: 1, 42: 1});
+    if (platformVersionCheck(2, 17)) {
+      // Dart VM versions before 2.17 don't support branch coverage.
+      expect(isolateFile?.branchHits,
+          {11: 1, 12: 1, 15: 0, 19: 1, 23: 1, 28: 1, 32: 0, 38: 1, 42: 1});
+    }
   });
 
   test('parseCoverage', () async {

--- a/test/collect_coverage_test.dart
+++ b/test/collect_coverage_test.dart
@@ -113,7 +113,7 @@ void main() {
   });
 
   test('HitMap.parseJson', () async {
-    final resultString = await _collectCoverage(true);
+    final resultString = await _collectCoverage(true, true);
     final jsonResult = json.decode(resultString) as Map<String, dynamic>;
     final coverage = jsonResult['coverage'] as List;
     final hitMap = await HitMap.parseJson(
@@ -179,6 +179,8 @@ void main() {
       28: 'fooAsync',
       38: 'isolateTask'
     });
+    expect(isolateFile?.branchHits,
+        {11: 1, 12: 1, 15: 0, 19: 1, 23: 1, 28: 1, 32: 0, 38: 1, 42: 1});
   });
 
   test('parseCoverage', () async {
@@ -289,9 +291,10 @@ void main() {
 String? _coverageData;
 
 Future<String> _getCoverageResult() async =>
-    _coverageData ??= await _collectCoverage(false);
+    _coverageData ??= await _collectCoverage(false, false);
 
-Future<String> _collectCoverage(bool functionCoverage) async {
+Future<String> _collectCoverage(
+    bool functionCoverage, bool branchCoverage) async {
   expect(FileSystemEntity.isFileSync(testAppPath), isTrue);
 
   final openPort = await getOpenPort();
@@ -316,9 +319,10 @@ Future<String> _collectCoverage(bool functionCoverage) async {
 
   // Run the collection tool.
   // TODO: need to get all of this functionality in the lib
-  final toolResult = await Process.run('dart', [
+  final toolResult = await Process.run(Platform.resolvedExecutable, [
     _collectAppPath,
     if (functionCoverage) '--function-coverage',
+    if (branchCoverage) '--branch-coverage',
     '--uri',
     '$serviceUri',
     '--resume-isolates',

--- a/test/collect_coverage_test.dart
+++ b/test/collect_coverage_test.dart
@@ -179,12 +179,78 @@ void main() {
       28: 'fooAsync',
       38: 'isolateTask'
     });
-    if (platformVersionCheck(2, 17)) {
-      // Dart VM versions before 2.17 don't support branch coverage.
-      expect(isolateFile?.branchHits,
-          {11: 1, 12: 1, 15: 0, 19: 1, 23: 1, 28: 1, 32: 0, 38: 1, 42: 1});
+    expect(isolateFile?.branchHits,
+        {11: 1, 12: 1, 15: 0, 19: 1, 23: 1, 28: 1, 32: 0, 38: 1, 42: 1});
+  }, skip: !platformVersionCheck(2, 17));
+
+  test('HitMap.parseJson, old VM without branch coverage', () async {
+    final resultString = await _collectCoverage(true, true);
+    final jsonResult = json.decode(resultString) as Map<String, dynamic>;
+    final coverage = jsonResult['coverage'] as List;
+    final hitMap = await HitMap.parseJson(
+      coverage.cast<Map<String, dynamic>>(),
+    );
+    expect(hitMap, contains(_sampleAppFileUri));
+
+    final isolateFile = hitMap[_isolateLibFileUri];
+    final expectedHits = {
+      11: 1,
+      12: 1,
+      13: 1,
+      15: 0,
+      19: 1,
+      23: 1,
+      24: 2,
+      28: 1,
+      29: 1,
+      30: 1,
+      32: 0,
+      38: 1,
+      39: 1,
+      41: 1,
+      42: 3,
+      43: 1,
+      44: 3,
+      45: 1,
+      48: 1,
+      49: 1,
+      51: 1,
+      54: 1,
+      55: 1,
+      56: 1,
+      59: 1,
+      60: 1,
+      62: 1,
+      63: 1,
+      64: 1,
+      66: 1,
+      67: 1,
+      68: 1
+    };
+    if (Platform.version.startsWith('1.')) {
+      // Dart VMs prior to 2.0.0-dev.5.0 contain a bug that emits coverage on the
+      // closing brace of async function blocks.
+      // See: https://github.com/dart-lang/coverage/issues/196
+      expectedHits[23] = 0;
+    } else {
+      // Dart VMs version 2.0.0-dev.6.0 mark the opening brace of a function as
+      // coverable.
+      expectedHits[11] = 1;
+      expectedHits[28] = 1;
+      expectedHits[38] = 1;
+      expectedHits[42] = 3;
     }
-  });
+    expect(isolateFile?.lineHits, expectedHits);
+    expect(isolateFile?.funcHits, {11: 1, 19: 1, 21: 0, 23: 1, 28: 1, 38: 1});
+    expect(isolateFile?.funcNames, {
+      11: 'fooSync',
+      19: 'BarClass.BarClass',
+      21: 'BarClass.x=',
+      23: 'BarClass.baz',
+      28: 'fooAsync',
+      38: 'isolateTask'
+    });
+  }, skip: platformVersionCheck(2, 17));
 
   test('parseCoverage', () async {
     final tempDir = await Directory.systemTemp.createTemp('coverage.test.');

--- a/test/lcov_test.dart
+++ b/test/lcov_test.dart
@@ -238,7 +238,8 @@ Future<Map<String, HitMap>> _getHitMap() async {
   final sampleAppArgs = [
     '--pause-isolates-on-exit',
     '--enable-vm-service=$port',
-    '--branch-coverage',
+    // Dart VM versions before 2.17 don't support branch coverage.
+    if (platformVersionCheck(2, 17)) '--branch-coverage',
     _sampleAppPath
   ];
   final sampleProcess =

--- a/test/lcov_test.dart
+++ b/test/lcov_test.dart
@@ -18,7 +18,7 @@ final _sampleAppFileUri = p.toUri(p.absolute(_sampleAppPath)).toString();
 final _isolateLibFileUri = p.toUri(p.absolute(_isolateLibPath)).toString();
 
 void main() {
-  /*test('validate hitMap', () async {
+  test('validate hitMap', () async {
     final hitmap = await _getHitMap();
 
     expect(hitmap, contains(_sampleAppFileUri));
@@ -29,6 +29,7 @@ void main() {
     final sampleAppHitLines = sampleAppHitMap?.lineHits;
     final sampleAppHitFuncs = sampleAppHitMap?.funcHits;
     final sampleAppFuncNames = sampleAppHitMap?.funcNames;
+    final sampleAppBranchHits = sampleAppHitMap?.branchHits;
 
     expect(sampleAppHitLines, containsPair(46, greaterThanOrEqualTo(1)),
         reason: 'be careful if you modify the test file');
@@ -42,9 +43,11 @@ void main() {
         reason: 'be careful if you modify the test file');
     expect(sampleAppFuncNames, containsPair(45, 'usedMethod'),
         reason: 'be careful if you modify the test file');
-  });*/
+    expect(sampleAppBranchHits, containsPair(41, 1),
+        reason: 'be careful if you modify the test file');
+  });
 
-  /*group('LcovFormatter', () {
+  group('LcovFormatter', () {
     test('format()', () async {
       final hitmap = await _getHitMap();
 
@@ -103,10 +106,10 @@ void main() {
           res, isNot(contains(p.absolute(p.join('lib', 'src', 'util.dart')))));
       expect(res, contains(p.join('src', 'util.dart')));
     });
-  });*/
+  });
 
   group('PrettyPrintFormatter', () {
-    /*test('format()', () async {
+    test('format()', () async {
       final hitmap = await _getHitMap();
 
       final resolver = Resolver(packagesPath: '.packages');
@@ -196,11 +199,10 @@ void main() {
       expect(res, contains('      1|int usedMethod(int a, int b) {'));
       expect(res, contains('      0|int unusedMethod(int a, int b) {'));
       expect(res, contains('       |  return a + b;'));
-    });*/
+    });
 
     test('prettyPrint() branches', () async {
       final hitmap = await _getHitMap();
-      print('HHHHHHH   ${hitmap}');
 
       final resolver = Resolver(packagesPath: '.packages');
       final res =
@@ -211,10 +213,9 @@ void main() {
       expect(res, contains(p.absolute(p.join('lib', 'src', 'util.dart'))));
 
       // be very careful if you change the test file
-      expect(res, contains('      1|  for (var i = 0; i < 10; i++) {'));
-      expect(res, contains('      1|      if (sum != (i + j)) {'));
-      expect(res, contains('      0|  if (value != 3) {'));
-      expect(res, contains('       |  print(result);'));
+      expect(res, contains('      1|  if (x == answer) {'));
+      expect(res, contains('      0|  while (i < lines.length) {'));
+      expect(res, contains('       |  bar.baz();'));
     });
   });
 }
@@ -254,7 +255,6 @@ Future<Map<String, HitMap>> _getHitMap() async {
   final coverageJson = (await collect(serviceUri, true, true, false, <String>{},
       functionCoverage: true,
       branchCoverage: true))['coverage'] as List<Map<String, dynamic>>;
-  print("SDLKGJSLDKFJGSD: $coverageJson");
   final hitMap = HitMap.parseJson(coverageJson);
 
   // wait for sample app to terminate.

--- a/test/lcov_test.dart
+++ b/test/lcov_test.dart
@@ -45,12 +45,35 @@ void main() {
         reason: 'be careful if you modify the test file');
     expect(sampleAppFuncNames, containsPair(45, 'usedMethod'),
         reason: 'be careful if you modify the test file');
-    if (platformVersionCheck(2, 17)) {
-      // Dart VM versions before 2.17 don't support branch coverage.
-      expect(sampleAppBranchHits, containsPair(41, 1),
-          reason: 'be careful if you modify the test file');
-    }
-  });
+    expect(sampleAppBranchHits, containsPair(41, 1),
+        reason: 'be careful if you modify the test file');
+  }, skip: !platformVersionCheck(2, 17));
+
+  test('validate hitMap, old VM without branch coverage', () async {
+    final hitmap = await _getHitMap();
+
+    expect(hitmap, contains(_sampleAppFileUri));
+    expect(hitmap, contains(_isolateLibFileUri));
+    expect(hitmap, contains('package:coverage/src/util.dart'));
+
+    final sampleAppHitMap = hitmap[_sampleAppFileUri];
+    final sampleAppHitLines = sampleAppHitMap?.lineHits;
+    final sampleAppHitFuncs = sampleAppHitMap?.funcHits;
+    final sampleAppFuncNames = sampleAppHitMap?.funcNames;
+
+    expect(sampleAppHitLines, containsPair(46, greaterThanOrEqualTo(1)),
+        reason: 'be careful if you modify the test file');
+    expect(sampleAppHitLines, containsPair(50, 0),
+        reason: 'be careful if you modify the test file');
+    expect(sampleAppHitLines, isNot(contains(32)),
+        reason: 'be careful if you modify the test file');
+    expect(sampleAppHitFuncs, containsPair(45, 1),
+        reason: 'be careful if you modify the test file');
+    expect(sampleAppHitFuncs, containsPair(49, 0),
+        reason: 'be careful if you modify the test file');
+    expect(sampleAppFuncNames, containsPair(45, 'usedMethod'),
+        reason: 'be careful if you modify the test file');
+  }, skip: platformVersionCheck(2, 17));
 
   group('LcovFormatter', () {
     test('format()', () async {
@@ -206,25 +229,22 @@ void main() {
       expect(res, contains('       |  return a + b;'));
     });
 
-    if (platformVersionCheck(2, 17)) {
-      // Dart VM versions before 2.17 don't support branch coverage.
-      test('prettyPrint() branches', () async {
-        final hitmap = await _getHitMap();
+    test('prettyPrint() branches', () async {
+      final hitmap = await _getHitMap();
 
-        final resolver = Resolver(packagesPath: '.packages');
-        final res =
-            await hitmap.prettyPrint(resolver, Loader(), reportBranches: true);
+      final resolver = Resolver(packagesPath: '.packages');
+      final res =
+          await hitmap.prettyPrint(resolver, Loader(), reportBranches: true);
 
-        expect(res, contains(p.absolute(_sampleAppPath)));
-        expect(res, contains(p.absolute(_isolateLibPath)));
-        expect(res, contains(p.absolute(p.join('lib', 'src', 'util.dart'))));
+      expect(res, contains(p.absolute(_sampleAppPath)));
+      expect(res, contains(p.absolute(_isolateLibPath)));
+      expect(res, contains(p.absolute(p.join('lib', 'src', 'util.dart'))));
 
-        // be very careful if you change the test file
-        expect(res, contains('      1|  if (x == answer) {'));
-        expect(res, contains('      0|  while (i < lines.length) {'));
-        expect(res, contains('       |  bar.baz();'));
-      });
-    }
+      // be very careful if you change the test file
+      expect(res, contains('      1|  if (x == answer) {'));
+      expect(res, contains('      0|  while (i < lines.length) {'));
+      expect(res, contains('       |  bar.baz();'));
+    }, skip: !platformVersionCheck(2, 17));
   });
 }
 

--- a/test/lcov_test.dart
+++ b/test/lcov_test.dart
@@ -11,6 +11,8 @@ import 'package:coverage/src/util.dart';
 import 'package:path/path.dart' as p;
 import 'package:test/test.dart';
 
+import 'test_util.dart';
+
 final _sampleAppPath = p.join('test', 'test_files', 'test_app.dart');
 final _isolateLibPath = p.join('test', 'test_files', 'test_app_isolate.dart');
 
@@ -43,8 +45,11 @@ void main() {
         reason: 'be careful if you modify the test file');
     expect(sampleAppFuncNames, containsPair(45, 'usedMethod'),
         reason: 'be careful if you modify the test file');
-    expect(sampleAppBranchHits, containsPair(41, 1),
-        reason: 'be careful if you modify the test file');
+    if (platformVersionCheck(2, 17)) {
+      // Dart VM versions before 2.17 don't support branch coverage.
+      expect(sampleAppBranchHits, containsPair(41, 1),
+          reason: 'be careful if you modify the test file');
+    }
   });
 
   group('LcovFormatter', () {
@@ -201,22 +206,25 @@ void main() {
       expect(res, contains('       |  return a + b;'));
     });
 
-    test('prettyPrint() branches', () async {
-      final hitmap = await _getHitMap();
+    if (platformVersionCheck(2, 17)) {
+      // Dart VM versions before 2.17 don't support branch coverage.
+      test('prettyPrint() branches', () async {
+        final hitmap = await _getHitMap();
 
-      final resolver = Resolver(packagesPath: '.packages');
-      final res =
-          await hitmap.prettyPrint(resolver, Loader(), reportBranches: true);
+        final resolver = Resolver(packagesPath: '.packages');
+        final res =
+            await hitmap.prettyPrint(resolver, Loader(), reportBranches: true);
 
-      expect(res, contains(p.absolute(_sampleAppPath)));
-      expect(res, contains(p.absolute(_isolateLibPath)));
-      expect(res, contains(p.absolute(p.join('lib', 'src', 'util.dart'))));
+        expect(res, contains(p.absolute(_sampleAppPath)));
+        expect(res, contains(p.absolute(_isolateLibPath)));
+        expect(res, contains(p.absolute(p.join('lib', 'src', 'util.dart'))));
 
-      // be very careful if you change the test file
-      expect(res, contains('      1|  if (x == answer) {'));
-      expect(res, contains('      0|  while (i < lines.length) {'));
-      expect(res, contains('       |  bar.baz();'));
-    });
+        // be very careful if you change the test file
+        expect(res, contains('      1|  if (x == answer) {'));
+        expect(res, contains('      0|  while (i < lines.length) {'));
+        expect(res, contains('       |  bar.baz();'));
+      });
+    }
   });
 }
 

--- a/test/run_and_collect_test.dart
+++ b/test/run_and_collect_test.dart
@@ -71,5 +71,6 @@ void main() {
     expect(actualLineHits, expectedLineHits);
     expect(actualHitMap?.funcHits, isNull);
     expect(actualHitMap?.funcNames, isNull);
+    expect(actualHitMap?.branchHits, isNull);
   });
 }

--- a/test/test_util.dart
+++ b/test/test_util.dart
@@ -19,3 +19,13 @@ Future<Process> runTestApp(int openPort) async {
     testAppPath
   ]);
 }
+
+final _versionPattern = RegExp('([0-9]+)\\.([0-9]+)\\.([0-9]+)');
+bool platformVersionCheck(int minMajor, int minMinor) {
+  final match = _versionPattern.matchAsPrefix(Platform.version);
+  if (match == null) return false;
+  if (match.groupCount < 3) return false;
+  final major = int.parse(match.group(1)!);
+  final minor = int.parse(match.group(2)!);
+  return major > minMajor || (major == minMajor && minor >= minMinor);
+}

--- a/test/test_util.dart
+++ b/test/test_util.dart
@@ -15,7 +15,8 @@ Future<Process> runTestApp(int openPort) async {
   return Process.start(Platform.resolvedExecutable, [
     '--enable-vm-service=$openPort',
     '--pause_isolates_on_exit',
-    '--branch-coverage',
+    // Dart VM versions before 2.17 don't support branch coverage.
+    if (platformVersionCheck(2, 17)) '--branch-coverage',
     testAppPath
   ]);
 }

--- a/test/test_util.dart
+++ b/test/test_util.dart
@@ -12,9 +12,10 @@ final String testAppPath = p.join('test', 'test_files', 'test_app.dart');
 const Duration timeout = Duration(seconds: 20);
 
 Future<Process> runTestApp(int openPort) async {
-  return Process.start('dart', [
+  return Process.start(Platform.resolvedExecutable, [
     '--enable-vm-service=$openPort',
     '--pause_isolates_on_exit',
+    '--branch-coverage',
     testAppPath
   ]);
 }


### PR DESCRIPTION
Implement branch coverage, using the new branch coverage source report from the VM service API.

To collect branch coverage information, pass `--branch-coverage` to *both* collect_coverage and the Dart command you're gathering coverage from. Branch coverage information can be pretty printed or included in lcov info. You'll also need a very recent version of the VM (service API v3.56, Dart VM v2.17).

Fixes #141 