### PR TITLE
Updates readme to use `dart pub`over `pub`

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Tools
 
 #### Install coverage
 
-    pub global activate coverage
+    dart pub global activate coverage
 
 Consider adding the `pub global run` executables directory to your path.
 See [Running a script from your PATH](https://dart.dev/tools/pub/cmd/pub-global#running-a-script-from-your-path)


### PR DESCRIPTION
The below command for activation is deprecated and should be replace with `dart pub`

```
$ pub global activate coverage
The top level `pub` command is deprecated. Use `dart pub` instead.
```

This PR updates the README to use 

```
dart pub global activate coverage
```