### PR TITLE
Handle new VM service message format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.1.1-dev
+
+* Add support for scraping the service URI from the new Dart VM service message.
+
 ## 1.1.0 - 2022-1-18
 
 * Support function level coverage information, when running tests in the Dart

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Dart.
 
 Tools
 -----
-`collect_coverage` collects coverage JSON from the Dart VM Observatory.
+`collect_coverage` collects coverage JSON from the Dart VM Service.
 `format_coverage` formats JSON coverage data into either
 [LCOV](http://ltp.sourceforge.net/coverage/lcov.php) or pretty-printed format.
 
@@ -33,7 +33,7 @@ or if the `pub global run` executables are on your PATH,
 collect_coverage --uri=http://... -o coverage.json --resume-isolates
 ```
 
-where `--uri` specifies the Observatory URI emitted by the VM.
+where `--uri` specifies the Dart VM Service URI emitted by the VM.
 
 If `collect_coverage` is invoked before the script from which coverage is to be
 collected, it will wait until it detects a VM observatory to which it can

--- a/lib/src/run_and_collect.dart
+++ b/lib/src/run_and_collect.dart
@@ -35,7 +35,7 @@ Future<Map<String, dynamic>> runAndCollect(String scriptPath,
       .transform(utf8.decoder)
       .transform(const LineSplitter())
       .listen((line) {
-    final uri = extractObservatoryUri(line);
+    final uri = extractVMServiceUri(line);
     if (uri != null) {
       serviceUriCompleter.complete(uri);
     }

--- a/lib/src/util.dart
+++ b/lib/src/util.dart
@@ -50,7 +50,7 @@ Uri? extractObservatoryUri(String str) => extractVMServiceUri(str);
 /// Potentially useful as a means to extract it from log statements.
 Uri? extractVMServiceUri(String str) {
   final listeningMessageRegExp = RegExp(
-      r'(?:Observatory|Dart VM Service) listening on ((http|//)[a-zA-Z0-9:/=_\-\.\[\]]+)',
+    r'(?:Observatory|Dart VM Service) listening on ((http|//)[a-zA-Z0-9:/=_\-\.\[\]]+)',
   );
   final match = listeningMessageRegExp.firstMatch(str);
   if (match != null) {

--- a/lib/src/util.dart
+++ b/lib/src/util.dart
@@ -41,17 +41,22 @@ Future<dynamic> retry(Future Function() f, Duration interval,
 /// Scrapes and returns the observatory URI from a string, or null if not found.
 ///
 /// Potentially useful as a means to extract it from log statements.
-Uri? extractObservatoryUri(String str) {
-  const kObservatoryListening = 'Observatory listening on ';
-  final msgPos = str.indexOf(kObservatoryListening);
-  if (msgPos == -1) return null;
-  final startPos = msgPos + kObservatoryListening.length;
-  final endPos = str.indexOf(RegExp(r'(\s|$)'), startPos);
-  try {
-    return Uri.parse(str.substring(startPos, endPos));
-  } on FormatException {
-    return null;
+@Deprecated('Use extractVMServiceUri instead')
+Uri? extractObservatoryUri(String str) => extractVMServiceUri(str);
+
+/// Scrapes and returns the Dart VM service URI from a string, or null if not
+/// found.
+///
+/// Potentially useful as a means to extract it from log statements.
+Uri? extractVMServiceUri(String str) {
+  final listeningMessageRegExp = RegExp(
+      r'(?:Observatory|Dart VM Service) listening on ((http|//)[a-zA-Z0-9:/=_\-\.\[\]]+)',
+  );
+  final match = listeningMessageRegExp.firstMatch(str);
+  if (match != null) {
+    return Uri.parse(match[1]!);
   }
+  return null;
 }
 
 /// Returns an open port by creating a temporary Socket

--- a/lib/src/util.dart
+++ b/lib/src/util.dart
@@ -38,12 +38,6 @@ Future<dynamic> retry(Future Function() f, Duration interval,
   }, duration: timeout);
 }
 
-/// Scrapes and returns the observatory URI from a string, or null if not found.
-///
-/// Potentially useful as a means to extract it from log statements.
-@Deprecated('Use extractVMServiceUri instead')
-Uri? extractObservatoryUri(String str) => extractVMServiceUri(str);
-
 /// Scrapes and returns the Dart VM service URI from a string, or null if not
 /// found.
 ///

--- a/test/collect_coverage_api_test.dart
+++ b/test/collect_coverage_api_test.dart
@@ -116,7 +116,7 @@ Future<Map<String, dynamic>> _collectCoverage(
       .transform(LineSplitter())
       .listen((line) {
     if (!serviceUriCompleter.isCompleted) {
-      final serviceUri = extractObservatoryUri(line);
+      final serviceUri = extractVMServiceUri(line);
       if (serviceUri != null) {
         serviceUriCompleter.complete(serviceUri);
       }

--- a/test/collect_coverage_test.dart
+++ b/test/collect_coverage_test.dart
@@ -306,7 +306,7 @@ Future<String> _collectCoverage(bool functionCoverage) async {
       .transform(LineSplitter())
       .listen((line) {
     if (!serviceUriCompleter.isCompleted) {
-      final serviceUri = extractObservatoryUri(line);
+      final serviceUri = extractVMServiceUri(line);
       if (serviceUri != null) {
         serviceUriCompleter.complete(serviceUri);
       }

--- a/test/lcov_test.dart
+++ b/test/lcov_test.dart
@@ -221,7 +221,7 @@ Future<Map<String, HitMap>> _getHitMap() async {
       .transform(LineSplitter())
       .listen((line) {
     if (!serviceUriCompleter.isCompleted) {
-      final serviceUri = extractObservatoryUri(line);
+      final serviceUri = extractVMServiceUri(line);
       if (serviceUri != null) {
         serviceUriCompleter.complete(serviceUri);
       }

--- a/test/util_test.dart
+++ b/test/util_test.dart
@@ -96,36 +96,42 @@ void main() {
     });
   });
 
-  group('extractObservatoryUri', () {
+  group('extractVMServiceUri', () {
     test('returns null when not found', () {
-      expect(extractObservatoryUri('foo bar baz'), isNull);
+      expect(extractVMServiceUri('foo bar baz'), isNull);
     });
 
     test('returns null for an incorrectly formatted URI', () {
       const msg = 'Observatory listening on :://';
-      expect(extractObservatoryUri(msg), null);
+      expect(extractVMServiceUri(msg), null);
     });
 
     test('returns URI at end of string', () {
       const msg = 'Observatory listening on http://foo.bar:9999/';
-      expect(extractObservatoryUri(msg), Uri.parse('http://foo.bar:9999/'));
+      expect(extractVMServiceUri(msg), Uri.parse('http://foo.bar:9999/'));
     });
 
     test('returns URI with auth token at end of string', () {
       const msg = 'Observatory listening on http://foo.bar:9999/cG90YXRv/';
-      expect(extractObservatoryUri(msg),
+      expect(extractVMServiceUri(msg),
           Uri.parse('http://foo.bar:9999/cG90YXRv/'));
     });
 
     test('return URI embedded within string', () {
       const msg = '1985-10-26 Observatory listening on http://foo.bar:9999/ **';
-      expect(extractObservatoryUri(msg), Uri.parse('http://foo.bar:9999/'));
+      expect(extractVMServiceUri(msg), Uri.parse('http://foo.bar:9999/'));
     });
 
     test('return URI with auth token embedded within string', () {
       const msg =
           '1985-10-26 Observatory listening on http://foo.bar:9999/cG90YXRv/ **';
-      expect(extractObservatoryUri(msg),
+      expect(extractVMServiceUri(msg),
+          Uri.parse('http://foo.bar:9999/cG90YXRv/'));
+    });
+
+    test('handles new Dart VM service message format', () {
+      const msg = 'Dart VM Service listening on http://foo.bar:9999/cG90YXRv/';
+      expect(extractVMServiceUri(msg),
           Uri.parse('http://foo.bar:9999/cG90YXRv/'));
     });
   });

--- a/test/util_test.dart
+++ b/test/util_test.dart
@@ -113,8 +113,8 @@ void main() {
 
     test('returns URI with auth token at end of string', () {
       const msg = 'Observatory listening on http://foo.bar:9999/cG90YXRv/';
-      expect(extractVMServiceUri(msg),
-          Uri.parse('http://foo.bar:9999/cG90YXRv/'));
+      expect(
+          extractVMServiceUri(msg), Uri.parse('http://foo.bar:9999/cG90YXRv/'));
     });
 
     test('return URI embedded within string', () {
@@ -125,14 +125,14 @@ void main() {
     test('return URI with auth token embedded within string', () {
       const msg =
           '1985-10-26 Observatory listening on http://foo.bar:9999/cG90YXRv/ **';
-      expect(extractVMServiceUri(msg),
-          Uri.parse('http://foo.bar:9999/cG90YXRv/'));
+      expect(
+          extractVMServiceUri(msg), Uri.parse('http://foo.bar:9999/cG90YXRv/'));
     });
 
     test('handles new Dart VM service message format', () {
       const msg = 'Dart VM Service listening on http://foo.bar:9999/cG90YXRv/';
-      expect(extractVMServiceUri(msg),
-          Uri.parse('http://foo.bar:9999/cG90YXRv/'));
+      expect(
+          extractVMServiceUri(msg), Uri.parse('http://foo.bar:9999/cG90YXRv/'));
     });
   });
 


### PR DESCRIPTION
"Observatory listening on..." is eventually being updated to "Dart VM
Service listening on...". This change allows for parsing the VM service
URI from messages of either format.

See https://github.com/dart-lang/sdk/issues/46756