### PR TITLE
Migrate tests to package_config.json

### DIFF
--- a/test/collect_coverage_test.dart
+++ b/test/collect_coverage_test.dart
@@ -299,7 +299,8 @@ void main() {
       await outputFile.writeAsString(coverageResults, flush: true);
 
       final parsedResult = await HitMap.parseFiles([outputFile],
-          packagesPath: '.packages', checkIgnoredLines: true);
+          packagesPath: '.dart_tool/package_config.json',
+          checkIgnoredLines: true);
 
       // This file has ignore:coverage-file.
       expect(parsedResult, isNot(contains(_sampleAppFileUri)));

--- a/test/lcov_test.dart
+++ b/test/lcov_test.dart
@@ -79,7 +79,7 @@ void main() {
     test('format()', () async {
       final hitmap = await _getHitMap();
 
-      final resolver = Resolver(packagesPath: '.packages');
+      final resolver = Resolver(packagesPath: '.dart_tool/package_config.json');
       // ignore: deprecated_member_use_from_same_package
       final formatter = LcovFormatter(resolver);
 
@@ -94,7 +94,7 @@ void main() {
     test('formatLcov()', () async {
       final hitmap = await _getHitMap();
 
-      final resolver = Resolver(packagesPath: '.packages');
+      final resolver = Resolver(packagesPath: '.dart_tool/package_config.json');
       final res = hitmap.formatLcov(resolver);
 
       expect(res, contains(p.absolute(_sampleAppPath)));
@@ -105,7 +105,7 @@ void main() {
     test('formatLcov() includes files in reportOn list', () async {
       final hitmap = await _getHitMap();
 
-      final resolver = Resolver(packagesPath: '.packages');
+      final resolver = Resolver(packagesPath: '.dart_tool/package_config.json');
       final res = hitmap.formatLcov(resolver, reportOn: ['lib/', 'test/']);
 
       expect(res, contains(p.absolute(_sampleAppPath)));
@@ -116,7 +116,7 @@ void main() {
     test('formatLcov() excludes files not in reportOn list', () async {
       final hitmap = await _getHitMap();
 
-      final resolver = Resolver(packagesPath: '.packages');
+      final resolver = Resolver(packagesPath: '.dart_tool/package_config.json');
       final res = hitmap.formatLcov(resolver, reportOn: ['lib/']);
 
       expect(res, isNot(contains(p.absolute(_sampleAppPath))));
@@ -127,7 +127,7 @@ void main() {
     test('formatLcov() uses paths relative to basePath', () async {
       final hitmap = await _getHitMap();
 
-      final resolver = Resolver(packagesPath: '.packages');
+      final resolver = Resolver(packagesPath: '.dart_tool/package_config.json');
       final res = hitmap.formatLcov(resolver, basePath: p.absolute('lib'));
 
       expect(
@@ -140,7 +140,7 @@ void main() {
     test('format()', () async {
       final hitmap = await _getHitMap();
 
-      final resolver = Resolver(packagesPath: '.packages');
+      final resolver = Resolver(packagesPath: '.dart_tool/package_config.json');
       // ignore: deprecated_member_use_from_same_package
       final formatter = PrettyPrintFormatter(resolver, Loader());
 
@@ -167,7 +167,7 @@ void main() {
     test('prettyPrint()', () async {
       final hitmap = await _getHitMap();
 
-      final resolver = Resolver(packagesPath: '.packages');
+      final resolver = Resolver(packagesPath: '.dart_tool/package_config.json');
       final res = await hitmap.prettyPrint(resolver, Loader());
 
       expect(res, contains(p.absolute(_sampleAppPath)));
@@ -190,7 +190,7 @@ void main() {
     test('prettyPrint() includes files in reportOn list', () async {
       final hitmap = await _getHitMap();
 
-      final resolver = Resolver(packagesPath: '.packages');
+      final resolver = Resolver(packagesPath: '.dart_tool/package_config.json');
       final res = await hitmap
           .prettyPrint(resolver, Loader(), reportOn: ['lib/', 'test/']);
 
@@ -202,7 +202,7 @@ void main() {
     test('prettyPrint() excludes files not in reportOn list', () async {
       final hitmap = await _getHitMap();
 
-      final resolver = Resolver(packagesPath: '.packages');
+      final resolver = Resolver(packagesPath: '.dart_tool/package_config.json');
       final res =
           await hitmap.prettyPrint(resolver, Loader(), reportOn: ['lib/']);
 
@@ -214,7 +214,7 @@ void main() {
     test('prettyPrint() functions', () async {
       final hitmap = await _getHitMap();
 
-      final resolver = Resolver(packagesPath: '.packages');
+      final resolver = Resolver(packagesPath: '.dart_tool/package_config.json');
       final res =
           await hitmap.prettyPrint(resolver, Loader(), reportFuncs: true);
 
@@ -232,7 +232,7 @@ void main() {
     test('prettyPrint() branches', () async {
       final hitmap = await _getHitMap();
 
-      final resolver = Resolver(packagesPath: '.packages');
+      final resolver = Resolver(packagesPath: '.dart_tool/package_config.json');
       final res =
           await hitmap.prettyPrint(resolver, Loader(), reportBranches: true);
 

--- a/tool/test_and_collect.sh
+++ b/tool/test_and_collect.sh
@@ -30,7 +30,7 @@ if [[ $(dart --version 2>&1 ) =~ '(dev)' ]]; then
     --lcov \
     --in=var/coverage.json \
     --out=var/lcov.info \
-    --packages=.packages \
+    --packages=.dart_tool/package_config.json \
     --report-on=lib \
     --check-ignore
 fi


### PR DESCRIPTION
Migrate tests to package_config.json, because .packages is doing away. The resolver still supports both .packages and package_config.json, and resolver_test.dart still tests both cases, for backwards compatibility.

#367