### PR TITLE
correctly parse package_config files on windows with relative root URI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
   is collected.
 * Add a `branchHits` field to `HitMap`.
 * Add support for scraping the service URI from the new Dart VM service message.
+* Correctly parse package_config files on Windows when the root URI is relative.
 
 ## 1.1.0 - 2022-1-18
 

--- a/lib/src/resolver.dart
+++ b/lib/src/resolver.dart
@@ -87,8 +87,9 @@ class Resolver {
   static Map<String, Uri> _parsePackages(String packagesPath) {
     final content = File(packagesPath).readAsStringSync();
     try {
+      final packagesUri = p.toUri(packagesPath);
       final parsed =
-          PackageConfig.parseString(content, Uri.base.resolve(packagesPath));
+          PackageConfig.parseString(content, Uri.base.resolveUri(packagesUri));
       return {
         for (var package in parsed.packages)
           package.name: package.packageUriRoot


### PR DESCRIPTION
When running `flutter test --coverage` on windows, we noticed that forcing package:coverage to use the package_config.json file would lead to errors like:

```
00:01 +1 -1: loading C:\Users\Jonah\flutter\examples\hello_world\test\hello_test.dart [E]
  Invalid argument(s): Uri c:/lib/ must have scheme 'file:'.
  package:path/src/style/windows.dart 86:7                       WindowsStyle.pathFromUri
  package:path/src/context.dart 1000:32                          Context.fromUri
  package:path/path.dart 417:32                                  fromUri
  package:coverage/src/resolver.dart 68:29                       Resolver.resolve
  package:coverage/src/hitmap.dart 60:31                         HitMap.parseJson
  ===== asynchronous gap ===========================
  package:flutter_tools/src/test/coverage_collector.dart 114:16  CoverageCollector.collectCoverage
  ===== asynchronous gap ===========================
  package:flutter_tools/src/test/coverage_collector.dart 33:5    CoverageCollector.handleFinishedTest
  ===== asynchronous gap ===========================
  package:flutter_tools/src/test/flutter_platform.dart 515:11    FlutterPlatform._startTest.<fn>
  ===== asynchronous gap ===========================
  dart:async/future.dart 611:5                                   Future.any.onValue
  ```
  
  It turns out that if the root URI in a package config file was relative, it was not parsed correctly since resolving the provided packagesPath was not working correctly on windows (resolving to wrong dir).
  
  To fix this, we first convert the provided packages path to a URI and then resolve that. Tests are updated to all pass on windows as well.
  
  Unblocks https://github.com/flutter/flutter/pull/99677 /  https://dart-review.googlesource.com/c/sdk/+/231101