### PR TITLE
Add version of parseJson that can cache file reads and parses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 1.4.0 - 2022-6-16
+
+* Added `HitMap.parseJsonSync` which takes a cache of ignored lines which can
+  speedup calls when `checkIgnoredLines` is true and the function is called
+  several times with overlapping files in the input json.
+
 ## 1.3.2
 
 * Fix test_with_coverage listening to an unsupported signal on windows.

--- a/lib/src/hitmap.dart
+++ b/lib/src/hitmap.dart
@@ -35,15 +35,21 @@ class HitMap {
 
   /// Creates a single hitmap from a raw json object.
   ///
+  /// Note that when [checkIgnoredLines] is `true` all files will be
+  /// read to get ignore comments. This will add some overhead.
+  /// To combat this when calling this function multiple times from the
+  /// same source (e.g. test runs of different files) a cache is taken
+  /// via [ignoredLinesInFilesCache]. If this cache contains the parsed
+  /// data for the specific file already, the file will not be read and
+  /// parsed again.
+  ///
   /// Throws away all entries that are not resolvable.
-  static Future<Map<String, HitMap>> parseJson(
+  static Map<String, HitMap> parseJsonSync(
     List<Map<String, dynamic>> jsonResult, {
-    bool checkIgnoredLines = false,
-    @Deprecated('Use packagePath') String? packagesPath,
-    String? packagePath,
-  }) async {
-    final resolver = await Resolver.create(
-        packagesPath: packagesPath, packagePath: packagePath);
+    required bool checkIgnoredLines,
+    required Map<String, List<List<int>>?> ignoredLinesInFilesCache,
+    required Resolver resolver,
+  }) {
     final loader = Loader();
 
     // Map of source file to map of line to hit count for that line.
@@ -59,16 +65,32 @@ class HitMap {
       var ignoredLinesList = <List<int>>[];
 
       if (checkIgnoredLines) {
-        final path = resolver.resolve(source);
-        if (path != null) {
-          final lines = await loader.load(path);
-          ignoredLinesList = getIgnoredLines(lines!);
-
-          // Ignore the whole file.
-          if (ignoredLinesList.length == 1 &&
-              ignoredLinesList[0][0] == 0 &&
-              ignoredLinesList[0][1] == lines.length) {
+        if (ignoredLinesInFilesCache.containsKey(source)) {
+          final List<List<int>>? cacheHit = ignoredLinesInFilesCache[source];
+          if (cacheHit == null) {
+            // Null-entry indicates that the whole file was ignored.
             continue;
+          }
+          ignoredLinesList = cacheHit;
+        } else {
+          final path = resolver.resolve(source);
+          if (path != null) {
+            final lines = loader.loadSync(path) ?? [];
+            ignoredLinesList = getIgnoredLines(lines);
+
+            // Ignore the whole file.
+            if (ignoredLinesList.length == 1 &&
+                ignoredLinesList[0][0] == 0 &&
+                ignoredLinesList[0][1] == lines.length) {
+              // Null-entry indicates that the whole file was ignored.
+              ignoredLinesInFilesCache[source] = null;
+              continue;
+            }
+            ignoredLinesInFilesCache[source] = ignoredLinesList;
+          } else {
+            // Couldn't resolve source. Allow cache to answer next time
+            // anyway.
+            ignoredLinesInFilesCache[source] = ignoredLinesList;
           }
         }
       }
@@ -155,6 +177,29 @@ class HitMap {
       }
     }
     return globalHitMap;
+  }
+
+  /// Creates a single hitmap from a raw json object.
+  ///
+  /// Throws away all entries that are not resolvable.
+  static Future<Map<String, HitMap>> parseJson(
+    List<Map<String, dynamic>> jsonResult, {
+    bool checkIgnoredLines = false,
+    @Deprecated('Use packagePath') String? packagesPath,
+    String? packagePath,
+  }) async {
+    final Resolver resolver = await createResolver(
+        packagesPath: packagesPath, packagePath: packagePath);
+    return parseJsonSync(jsonResult,
+        checkIgnoredLines: checkIgnoredLines,
+        ignoredLinesInFilesCache: {},
+        resolver: resolver);
+  }
+
+  static Future<Resolver> createResolver(
+      {String? packagesPath, String? packagePath}) async {
+    return await Resolver.create(
+        packagesPath: packagesPath, packagePath: packagePath);
   }
 
   /// Generates a merged hitmap from a set of coverage JSON files.

--- a/lib/src/hitmap.dart
+++ b/lib/src/hitmap.dart
@@ -188,18 +188,12 @@ class HitMap {
     @Deprecated('Use packagePath') String? packagesPath,
     String? packagePath,
   }) async {
-    final Resolver resolver = await createResolver(
+    final Resolver resolver = await Resolver.create(
         packagesPath: packagesPath, packagePath: packagePath);
     return parseJsonSync(jsonResult,
         checkIgnoredLines: checkIgnoredLines,
         ignoredLinesInFilesCache: {},
         resolver: resolver);
-  }
-
-  static Future<Resolver> createResolver(
-      {String? packagesPath, String? packagePath}) async {
-    return await Resolver.create(
-        packagesPath: packagesPath, packagePath: packagePath);
   }
 
   /// Generates a merged hitmap from a set of coverage JSON files.

--- a/lib/src/resolver.dart
+++ b/lib/src/resolver.dart
@@ -200,4 +200,16 @@ class Loader {
       return null;
     }
   }
+
+  /// Loads an imported resource and returns a [List] of lines.
+  /// Returns `null` if the resource could not be loaded.
+  List<String>? loadSync(String path) {
+    try {
+      // Ensure `readAsLinesSync` runs within the try block so errors are caught.
+      return File(path).readAsLinesSync();
+    } catch (_) {
+      failed.add(path);
+      return null;
+    }
+  }
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: coverage
-version: 1.3.2
+version: 1.4.0
 description: Coverage data manipulation and formatting
 repository: https://github.com/dart-lang/coverage
 

--- a/test/run_and_collect_test.dart
+++ b/test/run_and_collect_test.dart
@@ -40,7 +40,7 @@ void main() {
 
     final hitMap = await HitMap.parseJson(coverage, checkIgnoredLines: true);
     checkHitmap(hitMap);
-    final Resolver resolver = await HitMap.createResolver();
+    final Resolver resolver = await Resolver.create();
     final Map<String, List<List<int>>?> ignoredLinesInFilesCache = {};
     final hitMap2 = HitMap.parseJsonSync(coverage,
         checkIgnoredLines: true,

--- a/test/run_and_collect_test.dart
+++ b/test/run_and_collect_test.dart
@@ -39,38 +39,100 @@ void main() {
     }
 
     final hitMap = await HitMap.parseJson(coverage, checkIgnoredLines: true);
-    expect(hitMap, isNot(contains(_sampleAppFileUri)));
+    checkHitmap(hitMap);
+    final Resolver resolver = await HitMap.createResolver();
+    final Map<String, List<List<int>>?> ignoredLinesInFilesCache = {};
+    final hitMap2 = HitMap.parseJsonSync(coverage,
+        checkIgnoredLines: true,
+        ignoredLinesInFilesCache: ignoredLinesInFilesCache,
+        resolver: resolver);
+    checkHitmap(hitMap2);
+    checkIgnoredLinesInFilesCache(ignoredLinesInFilesCache);
 
-    final actualHitMap = hitMap[_isolateLibFileUri];
-    final actualLineHits = actualHitMap?.lineHits;
-    final expectedLineHits = {
-      11: 1,
-      12: 1,
-      13: 1,
-      15: 0,
-      19: 1,
-      23: 1,
-      24: 2,
-      28: 1,
-      29: 1,
-      30: 1,
-      32: 0,
-      38: 1,
-      39: 1,
-      41: 1,
-      42: 3,
-      43: 1,
-      44: 3,
-      45: 1,
-      48: 1,
-      49: 1,
-      59: 1,
-      60: 1
-    };
-
-    expect(actualLineHits, expectedLineHits);
-    expect(actualHitMap?.funcHits, isNull);
-    expect(actualHitMap?.funcNames, isNull);
-    expect(actualHitMap?.branchHits, isNull);
+    // Asking again the cache should answer questions about ignored lines,
+    // so providing a resolver that throws when asked for files should be ok.
+    final hitMap3 = HitMap.parseJsonSync(coverage,
+        checkIgnoredLines: true,
+        ignoredLinesInFilesCache: ignoredLinesInFilesCache,
+        resolver: ThrowingResolver());
+    checkHitmap(hitMap3);
+    checkIgnoredLinesInFilesCache(ignoredLinesInFilesCache);
   });
+}
+
+class ThrowingResolver implements Resolver {
+  @override
+  List<String> get failed => throw UnimplementedError();
+
+  @override
+  String? get packagePath => throw UnimplementedError();
+
+  @override
+  String? get packagesPath => throw UnimplementedError();
+
+  @override
+  String? resolve(String scriptUri) => throw UnimplementedError();
+
+  @override
+  String? resolveSymbolicLinks(String path) => throw UnimplementedError();
+
+  @override
+  String? get sdkRoot => throw UnimplementedError();
+}
+
+void checkIgnoredLinesInFilesCache(
+    Map<String, List<List<int>>?> ignoredLinesInFilesCache) {
+  expect(ignoredLinesInFilesCache.length, 3);
+  final List<String> keys = ignoredLinesInFilesCache.keys.toList();
+  final String testAppKey =
+      keys.where((element) => element.endsWith('test_app.dart')).single;
+  final String testAppIsolateKey =
+      keys.where((element) => element.endsWith('test_app_isolate.dart')).single;
+  final String packageUtilKey = keys
+      .where((element) => element.endsWith('package:coverage/src/util.dart'))
+      .single;
+  expect(ignoredLinesInFilesCache[packageUtilKey], []);
+  expect(ignoredLinesInFilesCache[testAppKey], null /* means whole file */);
+  expect(ignoredLinesInFilesCache[testAppIsolateKey], [
+    [51, 51],
+    [53, 57],
+    [62, 65],
+    [66, 69]
+  ]);
+}
+
+void checkHitmap(Map<String, HitMap> hitMap) {
+  expect(hitMap, isNot(contains(_sampleAppFileUri)));
+
+  final actualHitMap = hitMap[_isolateLibFileUri];
+  final actualLineHits = actualHitMap?.lineHits;
+  final expectedLineHits = {
+    11: 1,
+    12: 1,
+    13: 1,
+    15: 0,
+    19: 1,
+    23: 1,
+    24: 2,
+    28: 1,
+    29: 1,
+    30: 1,
+    32: 0,
+    38: 1,
+    39: 1,
+    41: 1,
+    42: 3,
+    43: 1,
+    44: 3,
+    45: 1,
+    48: 1,
+    49: 1,
+    59: 1,
+    60: 1
+  };
+
+  expect(actualLineHits, expectedLineHits);
+  expect(actualHitMap?.funcHits, isNull);
+  expect(actualHitMap?.funcNames, isNull);
+  expect(actualHitMap?.branchHits, isNull);
 }


### PR DESCRIPTION
When checkIgnoredLines is true parseJson reads files to find
ignore data for that file.
If calling parseJson several times for the same project,
as for instance done in flutter, this adds significant overhead.

This commit adds a new function - parseJsonSync - which is passed
a cache of the lookups. This way future lookups for the same
file will be faster. The new function is also sync avoiding any
potential race conditions when filling up the cache.

This - in combination with a change on the Flutter side -
reduces the overhead of collecting coverage in Flutter.
On my machine running `flutter test --coverage` in `flutter/packages/flutter`
goes from ~13.5 minutes to ~10 minutes.