### PR TITLE
Fix handling of part files in function coverage

### DIFF
--- a/lib/src/collect.dart
+++ b/lib/src/collect.dart
@@ -308,8 +308,7 @@ Future<List<Map<String, dynamic>>> _getCoverageJson(
     }
     final hits = getHitMap(Uri.parse(script.uri!));
     hits.funcHits ??= <int, int>{};
-    hits.funcNames ??= <int, String>{};
-    hits.funcNames![line] = funcName;
+    (hits.funcNames ??= <int, String>{})[line] = funcName;
   }
 
   for (var range in report.ranges!) {

--- a/lib/src/collect.dart
+++ b/lib/src/collect.dart
@@ -298,7 +298,6 @@ Future<List<Map<String, dynamic>>> _getCoverageJson(
     final funcName = await _getFuncName(service, isolateRef, func);
     final tokenPos = location.tokenPos!;
     final line = _getLineFromTokenPos(script, tokenPos);
-
     if (line == null) {
       if (_debugTokenPositions) {
         stderr.writeln(

--- a/lib/src/collect.dart
+++ b/lib/src/collect.dart
@@ -278,7 +278,9 @@ Future<List<Map<String, dynamic>>> _getCoverageJson(
     }
     return scripts[scriptRef];
   }
-  HitMap getHitMap(Uri scriptUri) => hitMaps.putIfAbsent(scriptUri, () => HitMap());
+
+  HitMap getHitMap(Uri scriptUri) =>
+      hitMaps.putIfAbsent(scriptUri, () => HitMap());
 
   Future<void> processFunction(FuncRef funcRef) async {
     final func = await service.getObject(isolateRef.id!, funcRef.id!) as Func;

--- a/lib/src/collect.dart
+++ b/lib/src/collect.dart
@@ -255,32 +255,6 @@ int? _getLineFromTokenPos(Script script, int tokenPos) {
   return null;
 }
 
-Future<void> _processFunction(VmService service, IsolateRef isolateRef,
-    Future<Script?> Function(ScriptRef?) scriptGetter, FuncRef funcRef, HitMap hits) async {
-  final func = await service.getObject(isolateRef.id!, funcRef.id!) as Func;
-  final location = func.location;
-  if (!(func.implicit ?? false) && location != null) {
-    return;
-  }
-  final script = await scriptGetter(location.script);
-  if (script == null) {
-    return;
-  }
-  final funcName = await _getFuncName(service, isolateRef, func);
-  final tokenPos = location.tokenPos!;
-  final line = _getLineFromTokenPos(script, tokenPos);
-
-  if (line == null) {
-    if (_debugTokenPositions) {
-      stderr.writeln(
-          'tokenPos $tokenPos in function ${funcRef.name} has no line '
-          'mapping for script ${script.uri!}');
-    }
-    return;
-  }
-  hits.funcNames![line] = funcName;
-}
-
 /// Returns a JSON coverage list backward-compatible with pre-1.16.0 SDKs.
 Future<List<Map<String, dynamic>>> _getCoverageJson(
     VmService service,
@@ -304,6 +278,38 @@ Future<List<Map<String, dynamic>>> _getCoverageJson(
     }
     return scripts[scriptRef];
   }
+  HitMap getHitMap(Uri scriptUri) => hitMaps.putIfAbsent(scriptUri, () => HitMap());
+
+  Future<void> processFunction(FuncRef funcRef) async {
+    final func = await service.getObject(isolateRef.id!, funcRef.id!) as Func;
+    if (func.implicit ?? false) {
+      return;
+    }
+    final location = func.location;
+    if (location == null) {
+      return;
+    }
+    final script = await getScript(location.script);
+    if (script == null) {
+      return;
+    }
+    final funcName = await _getFuncName(service, isolateRef, func);
+    final tokenPos = location.tokenPos!;
+    final line = _getLineFromTokenPos(script, tokenPos);
+
+    if (line == null) {
+      if (_debugTokenPositions) {
+        stderr.writeln(
+            'tokenPos $tokenPos in function ${funcRef.name} has no line '
+            'mapping for script ${script.uri!}');
+      }
+      return;
+    }
+    final hits = getHitMap(Uri.parse(script.uri!));
+    hits.funcHits ??= <int, int>{};
+    hits.funcNames ??= <int, String>{};
+    hits.funcNames![line] = funcName;
+  }
 
   for (var range in report.ranges!) {
     final scriptRef = report.scripts![range.scriptIndex!];
@@ -316,7 +322,7 @@ Future<List<Map<String, dynamic>>> _getCoverageJson(
     if (!includeDart && scriptUri.scheme == 'dart') continue;
 
     // Look up the hit maps for this script (shared across isolates).
-    final hits = hitMaps.putIfAbsent(scriptUri, () => HitMap());
+    final hits = getHitMap(scriptUri);
 
     Script? script;
     if (needScripts) {
@@ -327,14 +333,12 @@ Future<List<Map<String, dynamic>>> _getCoverageJson(
     // If the script's library isn't loaded, load it then look up all its funcs.
     final libRef = script?.library;
     if (functionCoverage && libRef != null && !libraries.contains(libRef)) {
-      hits.funcHits ??= <int, int>{};
-      hits.funcNames ??= <int, String>{};
       libraries.add(libRef);
       final library =
           await service.getObject(isolateRef.id!, libRef.id!) as Library;
       if (library.functions != null) {
         for (var funcRef in library.functions!) {
-          await _processFunction(service, isolateRef, getScript, funcRef, hits);
+          await processFunction(funcRef);
         }
       }
       if (library.classes != null) {
@@ -343,8 +347,7 @@ Future<List<Map<String, dynamic>>> _getCoverageJson(
               await service.getObject(isolateRef.id!, classRef.id!) as Class;
           if (clazz.functions != null) {
             for (var funcRef in clazz.functions!) {
-              await _processFunction(
-                  service, isolateRef, getScript, funcRef, hits);
+              await processFunction(funcRef);
             }
           }
         }

--- a/test/function_coverage_test.dart
+++ b/test/function_coverage_test.dart
@@ -66,10 +66,9 @@ void main() {
         p.absolute(p.join('test', 'test_files', 'test_library_part.dart'));
     final testLibraryPartUri = p.toUri(testLibraryPartPath).toString();
     expect(hitMap, contains(testLibraryPartUri));
-    // TODO(#399): Fix handling of part files then re-enable this check.
-    // final libraryPartFile = hitMap[testLibraryPartUri]!;
-    // expect(libraryPartFile.funcHits, {7: 1});
-    // expect(libraryPartFile.funcNames, {7: 'otherLibraryFunction'});
+    final libraryPartFile = hitMap[testLibraryPartUri]!;
+    expect(libraryPartFile.funcHits, {7: 1});
+    expect(libraryPartFile.funcNames, {7: 'otherLibraryFunction'});
   });
 }
 


### PR DESCRIPTION
The current logic looks up the script's library, then looks up all the functions in the library, and assumes that all those functions are in the script. But part files break this assumption.

So instead we have to look up the library, then for each of its functions, look up the corresponding script, and insert the function into that script's hitmap. Caching means that this isn't any slower.

Fixes #399