### PR TITLE
ignore-line comments etc must be at the end of the line

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 1.5.1
+
+- Fix bug where 'ingore-line' comments etc are applied even if they're inside
+  string literals.
+
 ## 1.5.0
 
 - Support passing extra arguments to `test_with_coverage` which are then passed

--- a/lib/src/util.dart
+++ b/lib/src/util.dart
@@ -74,10 +74,10 @@ Future<int> getOpenPort() async {
   }
 }
 
-const muliLineIgnoreStart = '// coverage:ignore-start';
-const muliLineIgnoreEnd = '// coverage:ignore-end';
-const singleLineIgnore = '// coverage:ignore-line';
-const ignoreFile = '// coverage:ignore-file';
+final muliLineIgnoreStart = RegExp(r'// coverage:ignore-start\s*$');
+final muliLineIgnoreEnd = RegExp(r'// coverage:ignore-end\s*$');
+final singleLineIgnore = RegExp(r'// coverage:ignore-line\s*$');
+final ignoreFile = RegExp(r'// coverage:ignore-file\s*$');
 
 /// Return list containing inclusive range of lines to be ignored by coverage.
 /// If there is a error in balancing the statements it will ignore nothing,

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: coverage
-version: 1.5.0
+version: 1.5.1
 description: Coverage data manipulation and formatting
 repository: https://github.com/dart-lang/coverage
 

--- a/test/test_files/test_app_isolate.dart
+++ b/test/test_files/test_app_isolate.dart
@@ -56,8 +56,8 @@ void isolateTask(dynamic threeThings) {
   print('3');
   // coverage:ignore-end
 
-  print('4');
-  print('5');
+  print('4 // coverage:ignore-line');
+  print('5 // coverage:ignore-file');
 
   print('6'); // coverage:ignore-start
   print('7');

--- a/test/util_test.dart
+++ b/test/util_test.dart
@@ -237,5 +237,39 @@ void main() {
         [3, 3],
       ]);
     });
+
+    test('Ingore comments have no effect inside string literals', () {
+      final lines = '''
+      final str = '// coverage:ignore-file';
+      final str = '// coverage:ignore-line';
+      final str = ''; // coverage:ignore-line
+      final str = '// coverage:ignore-start';
+      final str = '// coverage:ignore-end';
+      '''
+          .split('\n');
+
+      expect(getIgnoredLines(lines), [
+        [3, 3],
+      ]);
+    });
+
+    test('Allow white-space after ignore comments', () {
+      // Using multiple strings, rather than splitting a multi-line string,
+      // because many code editors remove trailing white-space.
+      final lines = [
+        "final str = ''; // coverage:ignore-start      ",
+        "final str = ''; // coverage:ignore-line\t",
+        "final str = ''; // coverage:ignore-end \t   \t   ",
+        "final str = ''; // coverage:ignore-line     \t ",
+        "final str = ''; // coverage:ignore-start    \t   ",
+        "final str = ''; // coverage:ignore-end  \t    \t ",
+      ];
+
+      expect(getIgnoredLines(lines), [
+        [1, 3],
+        [4, 4],
+        [5, 6],
+      ]);
+    });
   });
 }


### PR DESCRIPTION
This fixes #413, without the hassle of actually parsing all the strings (downside of this simple fix is that it's still possible for this bug to happen in multi-line strings). Before this, `print('// coverage:ignore-file');` would disable coverage for the file.

The fix is basically to make sure the line ends with the comment, rather than just containing it. But if I just used String.endsWith, then you'd end up with some very hard to debug errors:

```dart
// One of these is invalid:
// coverage:ignore-file
// coverage:ignore-file     
```

So instead I'm using regexps like `r'// coverage:ignore-file\s*$'`, to allow trailing white-space.