### PR TITLE
Ignore enhancements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## Current
+
+- allow omitting space between `//` and `coverage` in coverage ignore comments
+- allow text after coverage ignore comments
+- handle unbalanced ignore comments instead of silently erroring
+
 ## 1.6.3
 
 - Require Dart 2.18

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## Current
+## 1.6.4-wip.
 
 - allow omitting space between `//` and `coverage` in coverage ignore comments
 - allow text after coverage ignore comments

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 - allow omitting space between `//` and `coverage` in coverage ignore comments
 - allow text after coverage ignore comments
-- handle unbalanced ignore comments instead of silently erroring
+- throw FormatException when encountering unbalanced ignore comments instead of silently erroring
 
 ## 1.6.3
 

--- a/lib/src/hitmap.dart
+++ b/lib/src/hitmap.dart
@@ -76,7 +76,7 @@ class HitMap {
           final path = resolver.resolve(source);
           if (path != null) {
             final lines = loader.loadSync(path) ?? [];
-            ignoredLinesList = getIgnoredLines(lines);
+            ignoredLinesList = getIgnoredLines(path, lines);
 
             // Ignore the whole file.
             if (ignoredLinesList.length == 1 &&

--- a/lib/src/util.dart
+++ b/lib/src/util.dart
@@ -74,10 +74,10 @@ Future<int> getOpenPort() async {
   }
 }
 
-final muliLineIgnoreStart = RegExp(r'// coverage:ignore-start\s*$');
-final muliLineIgnoreEnd = RegExp(r'// coverage:ignore-end\s*$');
-final singleLineIgnore = RegExp(r'// coverage:ignore-line\s*$');
-final ignoreFile = RegExp(r'// coverage:ignore-file\s*$');
+final muliLineIgnoreStart = RegExp(r'//\s*coverage:ignore-start\s*$');
+final muliLineIgnoreEnd = RegExp(r'//\s*coverage:ignore-end\s*$');
+final singleLineIgnore = RegExp(r'//\s*coverage:ignore-line\s*$');
+final ignoreFile = RegExp(r'//\s*coverage:ignore-file\s*$');
 
 /// Return list containing inclusive range of lines to be ignored by coverage.
 /// If there is a error in balancing the statements it will ignore nothing,

--- a/lib/src/util.dart
+++ b/lib/src/util.dart
@@ -74,10 +74,10 @@ Future<int> getOpenPort() async {
   }
 }
 
-final muliLineIgnoreStart = RegExp(r'//\s*coverage:ignore-start\s*$');
-final muliLineIgnoreEnd = RegExp(r'//\s*coverage:ignore-end\s*$');
-final singleLineIgnore = RegExp(r'//\s*coverage:ignore-line\s*$');
-final ignoreFile = RegExp(r'//\s*coverage:ignore-file\s*$');
+final muliLineIgnoreStart = RegExp(r'//\s*coverage:ignore-start[\w\d\s]*$');
+final muliLineIgnoreEnd = RegExp(r'//\s*coverage:ignore-end[\w\d\s]*$');
+final singleLineIgnore = RegExp(r'//\s*coverage:ignore-line[\w\d\s]*$');
+final ignoreFile = RegExp(r'//\s*coverage:ignore-file[\w\d\s]*$');
 
 /// Return list containing inclusive range of lines to be ignored by coverage.
 /// If there is a error in balancing the statements it will ignore nothing,

--- a/lib/src/util.dart
+++ b/lib/src/util.dart
@@ -100,7 +100,7 @@ final ignoreFile = RegExp(r'//\s*coverage:ignore-file[\w\d\s]*$');
 /// ]
 /// ```
 ///
-List<List<int>> getIgnoredLines(List<String>? lines) {
+List<List<int>> getIgnoredLines(String filePath, List<String>? lines) {
   final ignoredLines = <List<int>>[];
   if (lines == null) return ignoredLines;
 
@@ -115,7 +115,7 @@ List<List<int>> getIgnoredLines(List<String>? lines) {
 
     if (lines[i].contains(muliLineIgnoreEnd)) {
       err ??= FormatException(
-        'unmatched coverage:ignore-end found on line ${i + 1}',
+        'unmatched coverage:ignore-end found at $filePath:${i + 1}',
       );
     }
 
@@ -129,7 +129,7 @@ List<List<int>> getIgnoredLines(List<String>? lines) {
         if (lines[i].contains(ignoreFile)) return allLines;
         if (lines[i].contains(muliLineIgnoreStart)) {
           err ??= FormatException(
-            'coverage:ignore-start found on line ${i + 1}'
+            'coverage:ignore-start found at $filePath:${i + 1}'
             ' before previous coverage:ignore-start ended',
           );
           break;
@@ -145,7 +145,7 @@ List<List<int>> getIgnoredLines(List<String>? lines) {
 
       if (isUnmatched) {
         err ??= FormatException(
-          'coverage:ignore-start found on line ${start + 1}'
+          'coverage:ignore-start found at $filePath:${start + 1}'
           ' has no matching coverage:ignore-end',
         );
       }

--- a/lib/src/util.dart
+++ b/lib/src/util.dart
@@ -108,36 +108,39 @@ List<List<int>> getIgnoredLines(List<String>? lines) {
     [0, lines.length]
   ];
 
-  var isError = false;
   var i = 0;
   while (i < lines.length) {
     if (lines[i].contains(ignoreFile)) return allLines;
 
-    if (lines[i].contains(muliLineIgnoreEnd)) isError = true;
-
     if (lines[i].contains(singleLineIgnore)) ignoredLines.add([i + 1, i + 1]);
 
     if (lines[i].contains(muliLineIgnoreStart)) {
+      var rangeCount = 1;
       final start = i;
       ++i;
       while (i < lines.length) {
-        if (lines[i].contains(ignoreFile)) return allLines;
-        if (lines[i].contains(muliLineIgnoreStart)) {
-          isError = true;
-          break;
-        }
-
-        if (lines[i].contains(muliLineIgnoreEnd)) {
-          ignoredLines.add([start + 1, i + 1]);
-          break;
+        final line = lines[i];
+        if (line.contains(ignoreFile)) return allLines;
+        if (line.contains(muliLineIgnoreStart)) {
+          rangeCount++;
+        } else if (line.contains(muliLineIgnoreEnd)) {
+          if (--rangeCount == 0) {
+            ignoredLines.add([start + 1, i + 1]);
+            break;
+          }
         }
         ++i;
+      }
+
+      if (rangeCount > 0) {
+        // unmatched muliLineIgnoreStart
+        ignoredLines.add([start + 1, i]);
       }
     }
     ++i;
   }
 
-  return isError ? [] : ignoredLines;
+  return ignoredLines;
 }
 
 extension StandardOutExtension on Stream<List<int>> {

--- a/test/util_test.dart
+++ b/test/util_test.dart
@@ -194,7 +194,7 @@ void main() {
       }
     });
 
-    test('Returns [[0,lines.length]] when the whole file is ignored', () {
+    test('returns [[0,lines.length]] when the whole file is ignored', () {
       final lines = '''final str = ''; // coverage:ignore-start
       final str = ''; // coverage:ignore-end
       final str = ''; // coverage:ignore-file
@@ -238,7 +238,7 @@ void main() {
       ]);
     });
 
-    test('Ingore comments have no effect inside string literals', () {
+    test('ignore comments have no effect inside string literals', () {
       final lines = '''
       final str = '// coverage:ignore-file';
       final str = '// coverage:ignore-line';
@@ -253,7 +253,7 @@ void main() {
       ]);
     });
 
-    test('Allow white-space after ignore comments', () {
+    test('allow white-space after ignore comments', () {
       // Using multiple strings, rather than splitting a multi-line string,
       // because many code editors remove trailing white-space.
       final lines = [

--- a/test/util_test.dart
+++ b/test/util_test.dart
@@ -177,44 +177,10 @@ void main() {
     ];
 
     test('throws FormatException when the annotations are not balanced', () {
-      for (var i = 0; i < invalidSources.length; ++i) {
-        late String errMsg;
-        switch (i) {
-          case 0:
-            errMsg = 'coverage:ignore-start found at content-0.dart:3'
-                ' before previous coverage:ignore-start ended';
-            break;
-          case 1:
-            errMsg = 'coverage:ignore-start found at content-1.dart:3'
-                ' before previous coverage:ignore-start ended';
-            break;
-          case 2:
-            errMsg = 'unmatched coverage:ignore-end found at content-2.dart:5';
-            break;
-          case 3:
-            errMsg = 'unmatched coverage:ignore-end found at content-3.dart:1';
-            break;
-          case 4:
-            errMsg = 'unmatched coverage:ignore-end found at content-4.dart:1';
-            break;
-          case 5:
-            errMsg = 'unmatched coverage:ignore-end found at content-5.dart:1';
-            break;
-          case 6:
-            errMsg = 'unmatched coverage:ignore-end found at content-6.dart:1';
-            break;
-          case 7:
-            errMsg =
-                'coverage:ignore-start found at content-7.dart:1 has no matching'
-                ' coverage:ignore-end';
-            break;
-          default:
-            throw UnimplementedError('expectation for not balanced case $i');
-        }
-
-        final content = invalidSources[i].split('\n');
+      void runTest(int index, String errMsg) {
+        final content = invalidSources[index].split('\n');
         expect(
-          () => getIgnoredLines('content-$i.dart', content),
+          () => getIgnoredLines('content-$index.dart', content),
           throwsA(
             allOf(
               isFormatException,
@@ -224,6 +190,39 @@ void main() {
           reason: 'expected FormatException with message "$errMsg"',
         );
       }
+
+      runTest(
+        0,
+        'coverage:ignore-start found at content-0.dart:3 before previous coverage:ignore-start ended',
+      );
+      runTest(
+        1,
+        'coverage:ignore-start found at content-1.dart:3 before previous coverage:ignore-start ended',
+      );
+      runTest(
+        2,
+        'unmatched coverage:ignore-end found at content-2.dart:5',
+      );
+      runTest(
+        3,
+        'unmatched coverage:ignore-end found at content-3.dart:1',
+      );
+      runTest(
+        4,
+        'unmatched coverage:ignore-end found at content-4.dart:1',
+      );
+      runTest(
+        5,
+        'unmatched coverage:ignore-end found at content-5.dart:1',
+      );
+      runTest(
+        6,
+        'unmatched coverage:ignore-end found at content-6.dart:1',
+      );
+      runTest(
+        7,
+        'coverage:ignore-start found at content-7.dart:1 has no matching coverage:ignore-end',
+      );
     });
 
     test(

--- a/test/util_test.dart
+++ b/test/util_test.dart
@@ -271,5 +271,22 @@ void main() {
         [5, 6],
       ]);
     });
+
+    test('allow omitting space after //', () {
+      final lines = [
+        "final str = ''; //coverage:ignore-start",
+        "final str = ''; //coverage:ignore-line",
+        "final str = ''; //coverage:ignore-end",
+        "final str = ''; //coverage:ignore-line",
+        "final str = ''; //coverage:ignore-start",
+        "final str = ''; //coverage:ignore-end",
+      ];
+
+      expect(getIgnoredLines(lines), [
+        [1, 3],
+        [4, 4],
+        [5, 6],
+      ]);
+    });
   });
 }

--- a/test/util_test.dart
+++ b/test/util_test.dart
@@ -288,5 +288,22 @@ void main() {
         [5, 6],
       ]);
     });
+
+    test('allow text after ignore comments', () {
+      final lines = [
+        "final str = ''; // coverage:ignore-start due to XYZ",
+        "final str = ''; // coverage:ignore-line",
+        "final str = ''; // coverage:ignore-end due to XYZ",
+        "final str = ''; // coverage:ignore-line due to 123",
+        "final str = ''; // coverage:ignore-start",
+        "final str = ''; // coverage:ignore-end it is done",
+      ];
+
+      expect(getIgnoredLines(lines), [
+        [1, 3],
+        [4, 4],
+        [5, 6],
+      ]);
+    });
   });
 }

--- a/test/util_test.dart
+++ b/test/util_test.dart
@@ -177,11 +177,51 @@ void main() {
     ];
 
     test('throws FormatException when the annotations are not balanced', () {
-      for (final content in invalidSources) {
+      for (var i = 0; i < invalidSources.length; ++i) {
+        late String errMsg;
+        switch (i) {
+          case 0:
+            errMsg = 'coverage:ignore-start found at content-0.dart:3'
+                ' before previous coverage:ignore-start ended';
+            break;
+          case 1:
+            errMsg = 'coverage:ignore-start found at content-1.dart:3'
+                ' before previous coverage:ignore-start ended';
+            break;
+          case 2:
+            errMsg = 'unmatched coverage:ignore-end found at content-2.dart:5';
+            break;
+          case 3:
+            errMsg = 'unmatched coverage:ignore-end found at content-3.dart:1';
+            break;
+          case 4:
+            errMsg = 'unmatched coverage:ignore-end found at content-4.dart:1';
+            break;
+          case 5:
+            errMsg = 'unmatched coverage:ignore-end found at content-5.dart:1';
+            break;
+          case 6:
+            errMsg = 'unmatched coverage:ignore-end found at content-6.dart:1';
+            break;
+          case 7:
+            errMsg =
+                'coverage:ignore-start found at content-7.dart:1 has no matching'
+                ' coverage:ignore-end';
+            break;
+          default:
+            throw UnimplementedError('expectation for not balanced case $i');
+        }
+
+        final content = invalidSources[i].split('\n');
         expect(
-          () => getIgnoredLines(content.split('\n')),
-          throwsFormatException,
-          reason: content,
+          () => getIgnoredLines('content-$i.dart', content),
+          throwsA(
+            allOf(
+              isFormatException,
+              predicate((FormatException e) => e.message == errMsg),
+            ),
+          ),
+          reason: 'expected FormatException with message "$errMsg"',
         );
       }
     });
@@ -192,7 +232,7 @@ void main() {
       for (final content in invalidSources) {
         final lines = content.split('\n');
         lines.add(' // coverage:ignore-file');
-        expect(getIgnoredLines(lines), [
+        expect(getIgnoredLines('', lines), [
           [0, lines.length]
         ]);
       }
@@ -205,7 +245,7 @@ void main() {
       '''
           .split('\n');
 
-      expect(getIgnoredLines(lines), [
+      expect(getIgnoredLines('', lines), [
         [0, lines.length]
       ]);
     });
@@ -221,7 +261,7 @@ void main() {
       '''
           .split('\n');
 
-      expect(getIgnoredLines(lines), [
+      expect(getIgnoredLines('', lines), [
         [1, 3],
         [4, 6],
       ]);
@@ -235,7 +275,7 @@ void main() {
       '''
           .split('\n');
 
-      expect(getIgnoredLines(lines), [
+      expect(getIgnoredLines('', lines), [
         [1, 1],
         [2, 2],
         [3, 3],
@@ -252,7 +292,7 @@ void main() {
       '''
           .split('\n');
 
-      expect(getIgnoredLines(lines), [
+      expect(getIgnoredLines('', lines), [
         [3, 3],
       ]);
     });
@@ -269,7 +309,7 @@ void main() {
         "final str = ''; // coverage:ignore-end  \t    \t ",
       ];
 
-      expect(getIgnoredLines(lines), [
+      expect(getIgnoredLines('', lines), [
         [1, 3],
         [4, 4],
         [5, 6],
@@ -286,7 +326,7 @@ void main() {
         "final str = ''; //coverage:ignore-end",
       ];
 
-      expect(getIgnoredLines(lines), [
+      expect(getIgnoredLines('', lines), [
         [1, 3],
         [4, 4],
         [5, 6],
@@ -303,7 +343,7 @@ void main() {
         "final str = ''; // coverage:ignore-end it is done",
       ];
 
-      expect(getIgnoredLines(lines), [
+      expect(getIgnoredLines('', lines), [
         [1, 3],
         [4, 4],
         [5, 6],

--- a/test/util_test.dart
+++ b/test/util_test.dart
@@ -149,6 +149,7 @@ void main() {
         final str = ''; // coverage:ignore-end
         final str = '';
         final str = ''; // coverage:ignore-end
+        final str = '';
         ''',
       '''final str = ''; // coverage:ignore-start
         final str = '';
@@ -176,9 +177,39 @@ void main() {
         ''',
     ];
 
-    test('returns empty when the annotations are not balanced', () {
-      for (final content in invalidSources) {
-        expect(getIgnoredLines(content.split('\n')), isEmpty);
+    test('handles when the annotations are not balanced', () {
+      for (var i = 0; i < invalidSources.length; ++i) {
+        final lines = invalidSources[i].split('\n');
+        final res = getIgnoredLines(lines);
+
+        switch (i) {
+          case 0:
+            expect(res, [[1, lines.length]]);
+            break;
+          case 1:
+            expect(res, [[1, 6]]);
+            break;
+          case 2:
+            expect(res, [[1, 3]]);
+            break;
+          case 3:
+            expect(res, [[3, 5]]);
+            break;
+          case 4:
+            expect(res, isEmpty);
+            break;
+          case 5:
+            expect(res, [[3, lines.length]]);
+            break;
+          case 6:
+            expect(res, isEmpty);
+            break;
+          case 7:
+            expect(res, [[1, lines.length]]);
+            break;
+          default:
+            throw UnimplementedError('expectation for not balanced case $i');
+        }
       }
     });
 

--- a/test/util_test.dart
+++ b/test/util_test.dart
@@ -149,7 +149,6 @@ void main() {
         final str = ''; // coverage:ignore-end
         final str = '';
         final str = ''; // coverage:ignore-end
-        final str = '';
         ''',
       '''final str = ''; // coverage:ignore-start
         final str = '';
@@ -177,39 +176,13 @@ void main() {
         ''',
     ];
 
-    test('handles when the annotations are not balanced', () {
-      for (var i = 0; i < invalidSources.length; ++i) {
-        final lines = invalidSources[i].split('\n');
-        final res = getIgnoredLines(lines);
-
-        switch (i) {
-          case 0:
-            expect(res, [[1, lines.length]]);
-            break;
-          case 1:
-            expect(res, [[1, 6]]);
-            break;
-          case 2:
-            expect(res, [[1, 3]]);
-            break;
-          case 3:
-            expect(res, [[3, 5]]);
-            break;
-          case 4:
-            expect(res, isEmpty);
-            break;
-          case 5:
-            expect(res, [[3, lines.length]]);
-            break;
-          case 6:
-            expect(res, isEmpty);
-            break;
-          case 7:
-            expect(res, [[1, lines.length]]);
-            break;
-          default:
-            throw UnimplementedError('expectation for not balanced case $i');
-        }
+    test('throws FormatException when the annotations are not balanced', () {
+      for (final content in invalidSources) {
+        expect(
+          () => getIgnoredLines(content.split('\n')),
+          throwsFormatException,
+          reason: content,
+        );
       }
     });
 


### PR DESCRIPTION
Adds some enhancements to ignore comment handling:

1. allow omitting space between `//` and `coverage` in coverage ignore comments
2. allow text after coverage ignore comments
3. throw `FormatException` when encountering unbalanced ignore comments instead of silently erroring

Hopefully 1 and 2 are uncontroversial.
3 did change an existing test.
We found it quite confusing in our projects when seemingly ignored lines were still appearing as uncovered.
Only after much investigation would various devs discover that it was due to accidental nesting of ignore ranges.
To my mind, the coverage tool should lean towards being permissive (or maybe hard fail?). 
Potentially an analyzer rule could be added to detect unbalanced coverage ignore comments.

---

- [X] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/wiki/External-Package-Maintenance#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Note that many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.
</details>
