### PR TITLE
Copy collect_coverage's `--scope-output` flag to test_with_coverage.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 1.7.3
+## 1.8.0
 
 - Copy collect_coverage's `--scope-output` flag to test_with_coverage.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.7.3
+
+- Copy collect_coverage's `--scope-output` flag to test_with_coverage.
+
 ## 1.7.2
 
 - Update `package:vm_service` constraints to '>=12.0.0 <15.0.0'.

--- a/bin/test_with_coverage.dart
+++ b/bin/test_with_coverage.dart
@@ -80,6 +80,10 @@ ArgParser _createArgParser() => ArgParser()
     defaultsTo: false,
     help: 'Collect branch coverage info.',
   )
+  ..addMultiOption('scope-output',
+      help: 'restrict coverage results so that only scripts that start with '
+          'the provided package path are considered. Defaults to the name of '
+          'the package under test.')
   ..addFlag('help', abbr: 'h', negatable: false, help: 'Show this help.');
 
 class Flags {
@@ -90,7 +94,8 @@ class Flags {
     this.port,
     this.testScript,
     this.functionCoverage,
-    this.branchCoverage, {
+    this.branchCoverage,
+    this.scopeOutput, {
     required this.rest,
   });
 
@@ -101,6 +106,7 @@ class Flags {
   final String testScript;
   final bool functionCoverage;
   final bool branchCoverage;
+  final List<String> scopeOutput;
   final List<String> rest;
 }
 
@@ -154,6 +160,7 @@ ${parser.usage}
     args['test'] as String,
     args['function-coverage'] as bool,
     args['branch-coverage'] as bool,
+    args['scope-output'] as List<String>,
     rest: args.rest,
   );
 }
@@ -195,11 +202,13 @@ Future<void> main(List<String> arguments) async {
   );
   final serviceUri = await serviceUriCompleter.future;
 
+  final scopes =
+      flags.scopeOutput.isEmpty ? [flags.packageName] : flags.scopeOutput;
   await collect_coverage.main([
     '--wait-paused',
     '--resume-isolates',
     '--uri=$serviceUri',
-    '--scope-output=${flags.packageName}',
+    for (final scope in scopes) '--scope-output=$scope',
     if (flags.branchCoverage) '--branch-coverage',
     if (flags.functionCoverage) '--function-coverage',
     '-o',

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: coverage
-version: 1.7.2
+version: 1.8.0
 description: Coverage data manipulation and formatting
 repository: https://github.com/dart-lang/coverage
 


### PR DESCRIPTION
test_with_coverage is a wrapper around collect_coverage and format_coverage that sets sensible defaults for all their flags that are designed to cover 99% of the coverage use cases. I have a couple of coverage collection scripts in dart-lang/native that only exist because they need to customize the value of the `--scope-output` flag that's passed to collect_coverage. Seems reasonable to just expose the flag in test_with_coverage.

https://github.com/dart-lang/native/issues/1120