### PR TITLE
Exclude windows + Dart 3.4 from CI

### DIFF
--- a/.github/workflows/test-package.yml
+++ b/.github/workflows/test-package.yml
@@ -47,6 +47,11 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
         sdk: [3.4, dev]
+        exclude:
+          # VM service times out on windows before Dart 3.5
+          # https://github.com/dart-lang/coverage/issues/490
+          - os: windows-latest
+            sdk: 3.4
     steps:
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332
       - uses: dart-lang/setup-dart@0a8a0fc875eb934c15d08629302413c671d3f672


### PR DESCRIPTION
The VM service times out on Windows on SDKs before 3.5.

See https://github.com/dart-lang/coverage/issues/490