### PR TITLE
Replace <> with () in comment

### DIFF
--- a/test/test_util.dart
+++ b/test/test_util.dart
@@ -41,7 +41,7 @@ bool platformVersionCheck(int minMajor, int minMinor) {
   return major > minMajor || (major == minMajor && minor >= minMinor);
 }
 
-/// Returns a mapping of <URL: <function_name: hit_count>> from [sources].
+/// Returns a mapping of (URL: (function_name: hit_count)) from [sources].
 Map<String, Map<String, int>> functionInfoFromSources(
   Map<String, List<Map<dynamic, dynamic>>> sources,
 ) {


### PR DESCRIPTION
Apparently the latest analyzer doesn't like <> in comments: https://github.com/dart-lang/coverage/actions/runs/10343842383/job/28628528535